### PR TITLE
Publishing github release packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ go:
   - tip
 
 script: make test
+
+after_success:
+  - go get github.com/mitchellh/gox
+  - go get github.com/tcnksm/ghr
+  - make xcompile
+  - ghr -t $GITHUB_TOKEN -u allegro --replace `shell awk -F\" '/^const Version/ { print $$2 }' main.go` dist/

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,6 @@ xcompile: deps test
 		-os="openbsd" \
 		-os="solaris" \
 		-os="windows" \
-		-output="build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)"
-
-package: xcompile
-	$(eval FILES := $(shell ls build))
-	@mkdir -p build/tgz
-	for f in $(FILES); do \
-		(cd $(shell pwd)/build && tar -zcvf tgz/$$f.tar.gz $$f); \
-		echo $$f; \
-	done
+		-output "dist/$(NAME)_$(VERSION)_{{.OS}}_{{.Arch}}"
 
 .PHONY: all deps updatedeps build test xcompile package


### PR DESCRIPTION
https://github.com/tcnksm/ghr/wiki/Integrate-ghr-with-CI-as-a-Service#travisci
Requires ``$GITHUB_TOKEN`` set in travis and proper versioning instead of hardcoded ``Version`` in ``main.go``.