### PR TITLE
Hostname to Agent-address refactoring

### DIFF
--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -131,7 +131,7 @@ func TestRegisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 
 func TestDeregisterServices(t *testing.T) {
 	t.Parallel()
-	server := CreateNamedConsulTestServer("localhost", "dc1", t)
+	server := CreateConsulTestServer("dc1", t)
 	defer server.Stop()
 
 	consul := ConsulClientAtServer(server)
@@ -143,7 +143,7 @@ func TestDeregisterServices(t *testing.T) {
 	assert.Len(t, services, 2)
 
 	// when
-	consul.Deregister("serviceA", server.Config.NodeName)
+	consul.Deregister("serviceA", server.Config.Bind)
 
 	// then
 	services, _ = consul.GetAllServices()
@@ -153,7 +153,7 @@ func TestDeregisterServices(t *testing.T) {
 
 func TestDeregisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 	t.Parallel()
-	server := CreateNamedConsulTestServer("localhost", "dc1", t)
+	server := CreateConsulTestServer("dc1", t)
 	defer server.Stop()
 
 	consul := ConsulClientAtServer(server)
@@ -163,7 +163,7 @@ func TestDeregisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 
 	// when
 	server.Stop()
-	err := consul.Deregister("serviceA", server.Config.NodeName)
+	err := consul.Deregister("serviceA", server.Config.Bind)
 
 	// then
 	assert.Error(t, err)

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -12,13 +12,6 @@ func CreateConsulTestServer(dc string, t *testing.T) *testutil.TestServer {
 	})
 }
 
-func CreateNamedConsulTestServer(hostname string, dc string, t *testing.T) *testutil.TestServer {
-	return testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
-		c.Datacenter = dc
-		c.NodeName = hostname
-	})
-}
-
 func ConsulClientAtServer(server *testutil.TestServer) *Consul {
 	return consulClientAtAddress(server.Config.Bind, server.Config.Ports.HTTP)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -98,9 +98,12 @@ func (s Sync) deregisterConsulServicesThatAreNotInMarathonApps(apps []*apps.App,
 			}
 		}
 		if !found {
-			err := s.service.Deregister(instance.ServiceID, instance.Node)
+			err := s.service.Deregister(instance.ServiceID, instance.Address)
 			if err != nil {
-				log.WithError(err).WithField("Id", instance.ServiceID).Error("Can't deregister service")
+				log.WithError(err).WithFields(log.Fields{
+					"Id":      instance.ServiceID,
+					"Address": instance.Address,
+				}).Error("Can't deregister service")
 			}
 		}
 	}


### PR DESCRIPTION
We should not use Consul agent "node name" as a resolvable hostname, but rather stick to its Address.