### PR TITLE
Marathon leadership-aware sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ make test
 - Provided HTTP healtcheck will be transferred to Consul.
 - Labels with `tag` value will be converted to Consul tags, `marathon` tag is added by default
  (e.g, `labels: ["public":"tag", "varnish":"tag", "env": "test"]` → `tags: ["public", "varnish", "marathon"]`).
+- The scheduled Marathon-consul sync may run in two modes:
+    - Only on node that is the current [Marathon-leader](https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2-leader), `sync-leader` parameter should be set to `hostname:port` the current node appears in the Marathon cluster. 
+      This mode is **enabled by default** and the `sync-leader` property is set to the hostname resolved by OS.
+      Note that there is a difference between `sync-leader` and `marathon-location`: `sync-leader` is used for node leadership detection (should be set to cluster-wide node name), while `marathon-location` is used for connection purpose (may be set to `localhost`)
+    - On every node, `sync-force` parameter should be set to `true`
 
 ### Options
 
@@ -64,18 +69,21 @@ consul-ssl-ca-cert     |                       | Path to a CA certificate file, 
 consul-ssl-cert        |                       | Path to an SSL client certificate to use to authenticate to the Consul server
 consul-ssl-verify      | `true`                | Verify certificates when connecting via SSL
 consul-token           |                       | The Consul ACL token
-listen                 | :4000                 | Accept connections at this address
-log-level              | info                  | Log level: panic, fatal, error, warn, info, or debug
-log-format             | text                  | Log format: JSON, text
-marathon-location      | localhost:8080        | Marathon URL
+listen                 | `:4000`               | Accept connections at this address
+log-level              | `info`                | Log level: panic, fatal, error, warn, info, or debug
+log-format             | `text`                | Log format: JSON, text
+marathon-location      | `localhost:8080`      | Marathon URL
 marathon-password      |                       | Marathon password for basic auth
-marathon-protocol      | http                  | Marathon protocol (http or https)
+marathon-protocol      | `http`                | Marathon protocol (http or https)
 marathon-username      |                       | Marathon username for basic auth
-metrics-interval       | 30s                   | Metrics reporting [interval](https://golang.org/pkg/time/#Duration) **Note:** While using file configuration intervals should be provided in *nanoseconds*
+metrics-interval       | `30s`                 | Metrics reporting [interval](https://golang.org/pkg/time/#Duration) **Note:** While using file configuration intervals should be provided in *nanoseconds*
 metrics-location       |                       | Graphite URL (used when metrics-target is set to graphite)
-metrics-prefix         | default               | Metrics prefix (default is resolved to <hostname>.<app_name>
-metrics-target         | stdout                | Metrics destination stdout or graphite
-sync-interval          | 15m0s                 | Marathon-consul sync [interval](https://golang.org/pkg/time/#Duration) **Note:** While using file configuration intervals should be provided in *nanoseconds*
+metrics-prefix         | `default`             | Metrics prefix (resolved to `<hostname>.<app_name>` by default)
+metrics-target         | `stdout`              | Metrics destination stdout or graphite
+sync-enabled           | `true`                | Enable Marathon-consul scheduled sync
+sync-interval          | `15m0s`               | Marathon-consul sync [interval](https://golang.org/pkg/time/#Duration) **Note:** While using file configuration intervals should be provided in *nanoseconds*
+sync-leader            | `<hostname>:8080`     | Marathon cluster-wide node name (defaults to `<hostname>:8080`), the sync will run only if the node is the current [Marathon-leader](https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2-leader)
+sync-force             | `false`               | Force leadership-independent Marathon-consul sync (run always)
 
 
 ### Adding New Root Certificate Authorities

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,10 @@ func (config *Config) parseFlags() {
 	flag.StringVar(&config.Web.Listen, "listen", ":4000", "accept connections at this address")
 
 	// Sync
+	flag.BoolVar(&config.Sync.Enabled, "sync-enabled", true, "Enable Marathon-consul scheduled sync")
 	flag.DurationVar(&config.Sync.Interval, "sync-interval", 15*time.Minute, "Marathon-consul sync interval")
+	flag.StringVar(&config.Sync.Leader, "sync-leader", "", "Marathon cluster-wide node name (defaults to <hostname>:8080), the sync will run only if the specified node is the current Marathon-leader")
+	flag.BoolVar(&config.Sync.Force, "sync-force", false, "Force leadership-independent Marathon-consul sync (run always)")
 
 	// Marathon
 	flag.StringVar(&config.Marathon.Location, "marathon-location", "localhost:8080", "Marathon URL")

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	sync := sync.New(remote, service)
-	go sync.StartSyncServicesJob(config.Sync.Interval)
+	sync := sync.New(config.Sync, remote, service)
+	go sync.StartSyncServicesJob()
 
 	// set up routes
 	http.HandleFunc("/health", web.HealthHandler)

--- a/marathon/marathon_stub.go
+++ b/marathon/marathon_stub.go
@@ -10,6 +10,7 @@ type MarathonerStub struct {
 	AppsStub  []*apps.App
 	AppStub   map[tasks.AppId]*apps.App
 	TasksStub map[tasks.AppId][]*tasks.Task
+	leader    string
 }
 
 func (m MarathonerStub) Apps() ([]*apps.App, error) {
@@ -32,6 +33,16 @@ func (m MarathonerStub) Tasks(appId tasks.AppId) ([]*tasks.Task, error) {
 	}
 }
 
+func (m MarathonerStub) Leader() (string, error) {
+	return m.leader, nil
+}
+
+func MarathonerStubWithLeaderForApps(leader string, args ...*apps.App) *MarathonerStub {
+	stub := MarathonerStubForApps(args...)
+	stub.leader = leader
+	return stub
+}
+
 func MarathonerStubForApps(args ...*apps.App) *MarathonerStub {
 	appsMap := make(map[tasks.AppId]*apps.App)
 	tasksMap := make(map[tasks.AppId][]*tasks.Task)
@@ -50,5 +61,6 @@ func MarathonerStubForApps(args ...*apps.App) *MarathonerStub {
 		AppsStub:  args,
 		AppStub:   appsMap,
 		TasksStub: tasksMap,
+		leader:    "localhost:8080",
 	}
 }

--- a/marathon/marathon_stub_test.go
+++ b/marathon/marathon_stub_test.go
@@ -10,7 +10,11 @@ import (
 func TestMarathonStub(t *testing.T) {
 	t.Parallel()
 	// given
-	m := marathon.MarathonerStubForApps(utils.ConsulApp("/test/app", 3))
+	m := marathon.MarathonerStubWithLeaderForApps("some.host:1234", utils.ConsulApp("/test/app", 3))
+	// when
+	leader, _ := m.Leader()
+	// then
+	assert.Equal(t, "some.host:1234", leader)
 	// when
 	apps, _ := m.Apps()
 	// then
@@ -33,5 +37,4 @@ func TestMarathonStub(t *testing.T) {
 	// then
 	assert.Error(t, errOnNotExistingTasks)
 	assert.Nil(t, notExistingTasks)
-
 }

--- a/sync/config.go
+++ b/sync/config.go
@@ -3,5 +3,8 @@ package sync
 import "time"
 
 type Config struct {
+	Enabled  bool
 	Interval time.Duration
+	Leader   string
+	Force    bool
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/allegro/marathon-consul/apps"
 	service "github.com/allegro/marathon-consul/consul"
@@ -8,27 +9,42 @@ import (
 	"github.com/allegro/marathon-consul/metrics"
 	"github.com/allegro/marathon-consul/tasks"
 	consul "github.com/hashicorp/consul/api"
+	"os"
 	"time"
 )
 
 type Sync struct {
+	config   Config
 	marathon marathon.Marathoner
 	service  service.ConsulServices
 }
 
-func New(marathon marathon.Marathoner, service service.ConsulServices) *Sync {
-	return &Sync{marathon, service}
+func New(config Config, marathon marathon.Marathoner, service service.ConsulServices) *Sync {
+	return &Sync{config, marathon, service}
 }
 
-func (s *Sync) StartSyncServicesJob(interval time.Duration) *time.Ticker {
-	log.WithField("Interval", interval).Info("Marathon-consul sync job started")
-	ticker := time.NewTicker(interval)
+func (s *Sync) StartSyncServicesJob() *time.Ticker {
+	if !s.config.Enabled {
+		log.Info("Marathon-consul sync disabled")
+		return nil
+	}
+
+	log.WithFields(log.Fields{
+		"Interval": s.config.Interval,
+		"Leader":   s.config.Leader,
+		"Force":    s.config.Force,
+	}).Info("Marathon-consul sync job started")
+
+	ticker := time.NewTicker(s.config.Interval)
 	go func() {
 		s.SyncServices()
 		for {
 			select {
 			case <-ticker.C:
-				s.SyncServices()
+				err := s.SyncServices()
+				if err != nil {
+					log.WithError(err).Error("An error occured while performing sync")
+				}
 			}
 		}
 	}()
@@ -42,24 +58,58 @@ func (s *Sync) SyncServices() error {
 }
 
 func (s *Sync) syncServices() error {
+	if check, err := s.shouldPerformSync(); !check {
+		return err
+	}
 	log.Info("Syncing services started")
 
 	apps, err := s.marathon.Apps()
 	if err != nil {
-		return err
+		return fmt.Errorf("Can't get Marathon apps: %v", err)
 	}
-
 	s.registerMarathonApps(apps)
 
 	services, err := s.service.GetAllServices()
+	// TODO use services info to create new consul agents list, make (de)registration call only when needed
 	if err != nil {
-		log.WithError(err).Error("Can't get all Consul services")
-		return err
+		return fmt.Errorf("Can't get all Consul services: %v", err)
 	}
 
 	s.deregisterConsulServicesThatAreNotInMarathonApps(apps, services)
 
 	log.Info("Syncing services finished")
+	return nil
+}
+
+func (s *Sync) shouldPerformSync() (bool, error) {
+	if s.config.Force {
+		log.Debug("Forcing sync")
+		return true, nil
+	}
+	leader, err := s.marathon.Leader()
+	if err != nil {
+		return false, fmt.Errorf("Could not get Marathon leader: %v", err)
+	}
+	if s.config.Leader == "" {
+		if err = s.resolveHostname(); err != nil {
+			return false, fmt.Errorf("Could not resolve hostname: %v", err)
+		}
+	}
+	if leader != s.config.Leader {
+		log.WithField("Leader", leader).WithField("Node", s.config.Leader).Info("Node is not a leader, skipping sync")
+		return false, nil
+	}
+	log.WithField("Node", s.config.Leader).Info("Node has leadership")
+	return true, nil
+}
+
+func (s *Sync) resolveHostname() error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	s.config.Leader = fmt.Sprintf("%s:8080", hostname)
+	log.WithField("Leader", s.config.Leader).Info("Marathon-consul sync leader mode set to resolved hostname")
 	return nil
 }
 

--- a/sync/sync_bench_test.go
+++ b/sync/sync_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkDeregisterConsulServicesThatAreNotInMarathonApps100x100(b *testing
 func bench(b *testing.B, appsCount, instancesCount int) {
 	apps := marathonApps(appsCount, instancesCount)
 	instances := consulInstances(appsCount, instancesCount)
-	sync := New(nil, consul.NewConsulStub())
+	sync := New(Config{}, nil, consul.NewConsulStub())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Scheduled Marathon-Consul sync will run:
1. only when specified node has leadership
2. always when forced