### PR TITLE
Event-based deregistration fixed (now Consul-aware)

### DIFF
--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -32,6 +32,23 @@ func (c ConsulStub) GetAllServices() ([]*consulapi.CatalogService, error) {
 	return catalog, nil
 }
 
+func (c ConsulStub) GetServices(name tasks.AppId) ([]*consulapi.CatalogService, error) {
+	var catalog []*consulapi.CatalogService
+	for _, s := range c.services {
+		if s.Name == name.ConsulServiceName() && contains(s.Tags, "marathon") {
+			catalog = append(catalog, &consulapi.CatalogService{
+				Address:        s.Address,
+				ServiceAddress: s.Address,
+				ServicePort:    s.Port,
+				ServiceTags:    s.Tags,
+				ServiceID:      s.ID,
+				ServiceName:    s.Name,
+			})
+		}
+	}
+	return catalog, nil
+}
+
 func (c *ConsulStub) Register(service *consulapi.AgentServiceRegistration) error {
 	taskId := tasks.Id(service.ID)
 	if err, ok := c.ErrorServices[taskId]; ok {

--- a/consul/consul_stub_test.go
+++ b/consul/consul_stub_test.go
@@ -29,38 +29,68 @@ func TestConsulStub(t *testing.T) {
 	app := utils.ConsulApp("test", 3)
 	stubError := fmt.Errorf("Some error")
 	services, err := consul.GetAllServices()
+	testServices, err := consul.GetServices("test")
+
 	// then
 	assert.Empty(t, services)
+	assert.Empty(t, testServices)
 	assert.NoError(t, err)
+
 	// when
 	for _, task := range app.Tasks {
 		consul.Register(MarathonTaskToConsulService(task, app.HealthChecks, app.Labels))
 	}
 	services, _ = consul.GetAllServices()
+	testServices, _ = consul.GetServices("test")
+
 	// then
 	assert.Len(t, services, 3)
+	assert.Len(t, testServices, 3)
+
 	// when
 	err = consul.Deregister(app.Tasks[1].ID, "")
 	services, _ = consul.GetAllServices()
 	servicesIds := consul.RegisteredServicesIds()
+
 	// then
 	assert.NoError(t, err)
 	assert.Len(t, services, 2)
 	assert.Contains(t, servicesIds, "test.0")
 	assert.Contains(t, servicesIds, "test.2")
+
 	// given
 	consul.ErrorServices[app.Tasks[0].ID] = stubError
+
 	// when
 	err = consul.Deregister(app.Tasks[0].ID, "")
+
 	// then
 	assert.Equal(t, stubError, err)
+
 	// when
 	err = consul.Register(MarathonTaskToConsulService(app.Tasks[0], healthChecks, labels))
+
 	// then
 	assert.Equal(t, stubError, err)
+
 	// when
 	err = consul.Deregister(app.Tasks[2].ID, "")
+
 	// then
 	assert.NoError(t, err)
 	assert.Len(t, consul.RegisteredServicesIds(), 1)
+
+	// when
+	app = utils.ConsulApp("other", 2)
+	for _, task := range app.Tasks {
+		consul.Register(MarathonTaskToConsulService(task, app.HealthChecks, app.Labels))
+	}
+	services, _ = consul.GetAllServices()
+	testServices, _ = consul.GetServices("test")
+	otherServices, _ := consul.GetServices("other")
+
+	// then
+	assert.Len(t, consul.RegisteredServicesIds(), 3)
+	assert.Len(t, testServices, 1)
+	assert.Len(t, otherServices, 2)
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -142,6 +142,10 @@ func newConsulServicesMock() *ConsulServicesMock {
 	}
 }
 
+func (c *ConsulServicesMock) GetServices(name tasks.AppId) ([]*consulapi.CatalogService, error) {
+	return nil, nil
+}
+
 func (c *ConsulServicesMock) GetAllServices() ([]*consulapi.CatalogService, error) {
 	return nil, nil
 }
@@ -311,13 +315,18 @@ func (m errorMarathon) Leader() (string, error) {
 type errorConsul struct {
 }
 
+func (c errorConsul) GetServices(name tasks.AppId) ([]*consulapi.CatalogService, error) {
+	return nil, fmt.Errorf("Error occured")
+}
+
 func (c errorConsul) GetAllServices() ([]*consulapi.CatalogService, error) {
 	return nil, fmt.Errorf("Error occured")
 }
+
 func (c errorConsul) Register(service *consulapi.AgentServiceRegistration) error {
 	return fmt.Errorf("Error occured")
-
 }
+
 func (c errorConsul) Deregister(serviceId tasks.Id, agent string) error {
 	return fmt.Errorf("Error occured")
 }


### PR DESCRIPTION
Fixes #21 

There are some gentle changes in the behaviour of event handlers, 
for example: we don't return 400 if there are no services registered in Consul etc (they could be removed by other events or it's just some marathon-noise). 

(sorry for the blank lines added :P :cookie: :cake: :cherries: )