### PR TITLE
Fixes #72 | Unregister only tasks for given apps

### DIFF
--- a/apps/task.go
+++ b/apps/task.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 type Task struct {
@@ -19,6 +20,11 @@ type TaskId string
 
 func (id TaskId) String() string {
 	return string(id)
+}
+
+func (id TaskId) AppId() AppId {
+	index := strings.LastIndex(id.String(), ".")
+	return AppId("/" + strings.Replace(id.String()[0:index], "_", "/", -1))
 }
 
 type HealthCheckResult struct {

--- a/apps/task_test.go
+++ b/apps/task_test.go
@@ -108,3 +108,14 @@ func TestId_String(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "id", TaskId("id").String())
 }
+
+func TestId_AppId(t *testing.T) {
+	t.Parallel()
+	id := "pl.allegro_test_app.a7cde60e-0093-11e6-ab55-02aab772a161"
+	assert.Equal(t, AppId("/pl.allegro/test/app"), TaskId(id).AppId())
+}
+
+func TestId_AppIdForInvalid(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { TaskId("id").AppId() })
+}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -296,7 +296,7 @@ func TestSync_WithRegisteringProblems(t *testing.T) {
 	// given
 	marathon := marathon.MarathonerStubForApps(ConsulApp("/test/app", 3))
 	consul := consul.NewConsulStub()
-	consul.ErrorServices["/test/app.1"] = fmt.Errorf("Problem on registration")
+	consul.ErrorServices["test_app.1"] = fmt.Errorf("Problem on registration")
 	sync := newSyncWithDefaultConfig(marathon, consul)
 	// when
 	err := sync.SyncServices()

--- a/utils/apps.go
+++ b/utils/apps.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/allegro/marathon-consul/apps"
+	"strings"
 )
 
 func ConsulApp(name string, instances int) *apps.App {
@@ -23,7 +24,7 @@ func app(name string, instances int, consul bool, unhealthyInstances int) *apps.
 	for i := 0; i < instances; i++ {
 		task := apps.Task{
 			AppID: apps.AppId(name),
-			ID:    apps.TaskId(fmt.Sprintf("%s.%d", name, i)),
+			ID:    apps.TaskId(fmt.Sprintf("%s.%d", strings.Replace(strings.Trim(name, "/"), "/", "_", -1), i)),
 			Ports: []int{8080 + i},
 			Host:  "localhost",
 		}


### PR DESCRIPTION
This PR intorduce logic in killing stoped application. Only tasks from killed/stoped application will be deregistered.

This fixes #72 #35 #42