### PR TITLE
Fixes #83 | Unregister unhealthy killed tasks

### DIFF
--- a/events/unhealthy_task_kill.go
+++ b/events/unhealthy_task_kill.go
@@ -1,0 +1,20 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/allegro/marathon-consul/apps"
+)
+
+type UnhealthyTaskKilled struct {
+	Timestamp string      `json:"timestamp"`
+	ID        apps.TaskId `json:"taskId"`
+	AppID     apps.AppId  `json:"appId"`
+	Version   string      `json:"version"`
+}
+
+func ParseUnhealthyTaskKilled(event []byte) (*UnhealthyTaskKilled, error) {
+	task := &UnhealthyTaskKilled{}
+	err := json.Unmarshal(event, task)
+	return task, err
+}

--- a/events/unhealthy_task_kill_test.go
+++ b/events/unhealthy_task_kill_test.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var unhealthyTaskKill = &UnhealthyTaskKilled{
+	AppID: "/my-app",
+	ID:    "my-app_0-1396592784349",
+}
+
+func TestUnhealthTaskKillParseTask(t *testing.T) {
+	t.Parallel()
+
+	jsonified, err := json.Marshal(unhealthyTaskKill)
+	assert.Nil(t, err)
+
+	service, err := ParseUnhealthyTaskKilled(jsonified)
+	assert.Nil(t, err)
+
+	assert.Equal(t, unhealthyTaskKill.Timestamp, service.Timestamp)
+	assert.Equal(t, unhealthyTaskKill.ID, service.ID)
+	assert.Equal(t, unhealthyTaskKill.AppID, service.AppID)
+}


### PR DESCRIPTION
Marathon 1.1.1 introduced new event `unhealthy_task_kill_event`
that occurs when task is scheduled to kill after becomes unhealthy.
This change make marathon-consul aware of this event.