### PR TITLE
Fixes #81 configure consul name sparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ config-file            |                       | Path to a JSON file to read con
 consul-auth            | `false`               | Use Consul with authentication
 consul-auth-password   |                       | The basic authentication password
 consul-auth-username   |                       | The basic authentication username
+consul-name-separator  | `.`                   | Separator used to create default service name for Consul
 consul-port            | `8500`                | Consul port
 consul-ssl             | `false`               | Use HTTPS when talking to Consul
 consul-ssl-ca-cert     |                       | Path to a CA certificate file, containing one or more CA certificates to use to validate the certificate sent by the Consul server to us

--- a/apps/app.go
+++ b/apps/app.go
@@ -8,6 +8,10 @@ import (
 // Only Marathon apps with this label will be registered in Consul
 const MARATHON_CONSUL_LABEL = "consul"
 
+// Separator used between groups and task id
+// used when creating default service name for Consul
+var CONSUL_NAME_SEPARATOR = "."
+
 type HealthCheck struct {
 	Path                   string `json:"path"`
 	PortIndex              int    `json:"portIndex"`
@@ -46,7 +50,7 @@ func (id AppId) String() string {
 }
 
 func (id AppId) ConsulServiceName() string {
-	return strings.Replace(strings.Trim(strings.TrimSpace(id.String()), "/"), "/", ".", -1)
+	return strings.Replace(strings.Trim(strings.TrimSpace(id.String()), "/"), "/", CONSUL_NAME_SEPARATOR, -1)
 }
 
 func (app *App) IsConsulApp() bool {

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -133,6 +133,20 @@ func TestAppId_ConsulServiceName(t *testing.T) {
 	assert.Equal(t, "rootGroup.subGroup.subSubGroup.name", serviceName)
 }
 
+func TestAppId_ConsulServiceNameWithCustomSeparator(t *testing.T) {
+	// given
+	oldSeparator := CONSUL_NAME_SEPARATOR
+	defer func() { CONSUL_NAME_SEPARATOR = oldSeparator }()
+	CONSUL_NAME_SEPARATOR = "_"
+	id := AppId("/rootGroup/subGroup/subSubGroup/name")
+
+	// when
+	serviceName := id.ConsulServiceName()
+
+	// then
+	assert.Equal(t, "rootGroup_subGroup_subSubGroup_name", serviceName)
+}
+
 func TestConsulServiceName_BackwardCompatibilityForConsulTrue(t *testing.T) {
 	t.Parallel()
 

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ func (config *Config) parseFlags() {
 	flag.DurationVar(&config.Consul.Timeout, "consul-timeout", 3*time.Second, "Time limit for requests made by the Consul HTTP client. A Timeout of zero means no timeout")
 	flag.Uint32Var(&config.Consul.AgentFailuresTolerance, "consul-max-agent-failures", 3, "Max number of consecutive request failures for agent before removal from cache")
 	flag.Uint32Var(&config.Consul.RequestRetries, "consul-get-services-retry", 3, "Number of retries on failure when performing requests to Consul. Each retry uses different cached agent")
+	flag.StringVar(&config.Consul.ConsulNameSeparator, "consul-name-separator", ".", "Separator used to create default service name for Consul")
 
 	// Web
 	flag.StringVar(&config.Web.Listen, "listen", ":4000", "accept connections at this address")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,6 +99,7 @@ func TestConfig_ShouldBeMergedWithFileDefaultsAndFlags(t *testing.T) {
 			Timeout:                3 * time.Second,
 			RequestRetries:         5,
 			AgentFailuresTolerance: 3,
+			ConsulNameSeparator:    ".",
 		},
 		Web: web.Config{
 			Listen:       ":4000",

--- a/consul/config.go
+++ b/consul/config.go
@@ -14,6 +14,7 @@ type ConsulConfig struct {
 	Timeout                time.Duration
 	RequestRetries         uint32
 	AgentFailuresTolerance uint32
+	ConsulNameSeparator    string
 }
 
 type Auth struct {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -28,6 +28,7 @@ type Consul struct {
 type ServicesProvider func(agent *consulapi.Client) ([]*consulapi.CatalogService, error)
 
 func New(config ConsulConfig) *Consul {
+	apps.CONSUL_NAME_SEPARATOR = config.ConsulNameSeparator
 	return &Consul{
 		agents: NewAgents(&config),
 		config: config,

--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -21,7 +21,7 @@ func NewConsulStubWithTag(tag string) *ConsulStub {
 		services:         make(map[apps.TaskId]*consulapi.AgentServiceRegistration),
 		ErrorServices:    make(map[apps.TaskId]error),
 		ErrorGetServices: make(map[string]error),
-		consul:           New(ConsulConfig{Tag: tag}),
+		consul:           New(ConsulConfig{Tag: tag, ConsulNameSeparator: "."}),
 	}
 }
 

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -20,8 +20,9 @@ func ConsulClientAtServer(server *testutil.TestServer) *Consul {
 
 func consulClientAtAddress(host string, port int) *Consul {
 	config := ConsulConfig{
-		Timeout: 10 * time.Millisecond,
-		Port:    fmt.Sprintf("%d", port),
+		Timeout:             10 * time.Millisecond,
+		Port:                fmt.Sprintf("%d", port),
+		ConsulNameSeparator: ".",
 	}
 	consul := New(config)
 	// initialize the agents cache with a single client pointing at provided location

--- a/debian/config.json
+++ b/debian/config.json
@@ -5,6 +5,7 @@
       "Username": "",
       "Password": ""
     },
+    "ConsulNameSeparator": ".",
     "Port": "8500",
     "SslEnabled": false,
     "SslVerify": true,


### PR DESCRIPTION
Allow user to specify which separator will be used to create
default service name.