### PR TITLE
Fix wrong tag field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - go get github.com/mattn/goveralls
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
-  - make deps
+  - make build
   - go test -coverprofile=apps.coverprofile ./apps
   - go test -coverprofile=config.coverprofile ./config
   - go test -coverprofile=consul.coverprofile ./consul

--- a/apps/app.go
+++ b/apps/app.go
@@ -16,7 +16,7 @@ type HealthCheck struct {
 	TimeoutSeconds         int    `json:"timeoutSeconds"`
 	MaxConsecutiveFailures int    `json:"maxConsecutiveFailures"`
 	Command                struct {
-		Value string `json:"value`
+		Value string `json:"value"`
 	}
 }
 

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -534,7 +534,7 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 			{
 				Protocol: "COMMAND",
 				Command: struct {
-					Value string `json:"value`
+					Value string `json:"value"`
 				}{Value: "echo 1"},
 				IntervalSeconds:        30,
 				TimeoutSeconds:         20,


### PR DESCRIPTION
I notice that `make build` fails because two field tags are invalid. 
```
apps/app.go:19: struct field tag `json:"value` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
exit status 1
consul/consul_test.go:537: struct field tag `json:"value` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
exit status 1
make: *** [test] Error 1
```
I fixed it and change CI to check whole project builds not only tests pass.