### PR TITLE
Enable race detector in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGES=$(shell go list ./... | grep -v /vendor/)
-TESTARGS?=
+TESTARGS?=-race
 CURRENT_DIR = $(shell pwd)
 SOURCEDIR = $(CURRENT_DIR)
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestMark(t *testing.T) {
-	t.Parallel()
 	// given
 	Init(Config{Target: "stdout", Prefix: ""})
 
@@ -33,8 +32,6 @@ func TestMark(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel()
-
 	// given
 	Init(Config{Target: "stdout", Prefix: ""})
 
@@ -56,8 +53,6 @@ func TestTime(t *testing.T) {
 }
 
 func TestUpdateGauge(t *testing.T) {
-	t.Parallel()
-
 	// given
 	Init(Config{Target: "stdout", Prefix: ""})
 


### PR DESCRIPTION
Enable `-race` during tests and fix race conditions.