### PR TITLE
More efficient deregistering by task

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -57,7 +56,7 @@ func (c *Consul) getServicesUsingProviderWithRetriesOnAgentFailure(provide Servi
 }
 
 func (c *Consul) getServicesUsingAgent(name string, agent *consulapi.Client) ([]*service.Service, error) {
-	dcAwareQueries, err := dcAwareQueriesForAllDcs(agent)
+	dcAwareQueries, err := dcAwareQueriesForAllDCs(agent)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func (c *Consul) getServicesUsingAgent(name string, agent *consulapi.Client) ([]
 	return allServices, nil
 }
 
-func dcAwareQueriesForAllDcs(agent *consulapi.Client) ([]*consulapi.QueryOptions, error) {
+func dcAwareQueriesForAllDCs(agent *consulapi.Client) ([]*consulapi.QueryOptions, error) {
 	datacenters, err := agent.Catalog().Datacenters()
 	if err != nil {
 		return nil, err
@@ -94,7 +93,7 @@ func (c *Consul) GetAllServices() ([]*service.Service, error) {
 }
 
 func (c *Consul) getAllServices(agent *consulapi.Client) ([]*service.Service, error) {
-	dcAwareQueries, err := dcAwareQueriesForAllDcs(agent)
+	dcAwareQueries, err := dcAwareQueriesForAllDCs(agent)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +186,7 @@ func (c *Consul) DeregisterByTask(taskId apps.TaskId, agentAddress string) error
 	if err != nil {
 		return err
 	} else if len(services) == 0 {
-		return errors.New(fmt.Sprintf("Couldn't find any service matching task id %s", taskId))
+		return fmt.Errorf("Couldn't find any service matching task id %s", taskId)
 	}
 	return c.deregisterMultipleServices(services, taskId)
 }
@@ -206,7 +205,7 @@ func (c *Consul) deregisterMultipleServices(services []*service.Service, taskId 
 
 func (c *Consul) findServicesByTaskId(searchedTaskId apps.TaskId) ([]*service.Service, error) {
 	return c.getServicesUsingProviderWithRetriesOnAgentFailure(func(agent *consulapi.Client) ([]*service.Service, error) {
-		dcAwareQueries, err := dcAwareQueriesForAllDcs(agent)
+		dcAwareQueries, err := dcAwareQueriesForAllDCs(agent)
 		if err != nil {
 			return nil, err
 		}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -3,8 +3,8 @@ package service
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/allegro/marathon-consul/apps"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarathonTaskTAg(t *testing.T) {
@@ -16,7 +16,7 @@ func TestServiceTaskId(t *testing.T) {
 	t.Parallel()
 	// given
 	service := Service{
-		ID: "123",
+		ID:   "123",
 		Name: "abc",
 		RegisteringAgentAddress: "localhost",
 		Tags: []string{MarathonTaskTag("my-task")},
@@ -34,7 +34,7 @@ func TestServiceTaskId_NoMarathonTaskTag(t *testing.T) {
 	t.Parallel()
 	// given
 	service := Service{
-		ID: "123",
+		ID:   "123",
 		Name: "abc",
 		RegisteringAgentAddress: "localhost",
 		Tags: []string{},

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -1,0 +1,15 @@
+package utils
+
+import "fmt"
+
+func MergeErrorsOrNil(errors []error, description string) error {
+	if len(errors) == 0 {
+		return nil
+	}
+
+	errMessage := fmt.Sprintf("%d errors occured %s", len(errors), description)
+	for i, err := range errors {
+		errMessage = fmt.Sprintf("%s\n%d: %s", errMessage, i+1, err.Error())
+	}
+	return fmt.Errorf(errMessage)
+}

--- a/utils/errors_test.go
+++ b/utils/errors_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrors_shouldMergeErrors(t *testing.T) {
+	t.Parallel()
+	// given
+	errs := []error{errors.New("first"), errors.New("second")}
+
+	// when
+	err := MergeErrorsOrNil(errs, "testing")
+
+	// then
+	assert.EqualError(t, err, "2 errors occured testing\n1: first\n2: second")
+}
+
+func TestErrors_shouldReturnNilForEmptyErrors(t *testing.T) {
+	t.Parallel()
+	// expect
+	assert.NoError(t, MergeErrorsOrNil([]error{}, "testing"))
+}

--- a/web/event_handler.go
+++ b/web/event_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/allegro/marathon-consul/marathon"
 	"github.com/allegro/marathon-consul/metrics"
 	"github.com/allegro/marathon-consul/service"
+	"github.com/allegro/marathon-consul/utils"
 )
 
 type event struct {
@@ -195,11 +196,7 @@ func (fh *eventHandler) handleDeploymentInfo(body []byte) error {
 			errors = append(errors, err)
 		}
 	}
-	if len(errors) > 0 {
-		return fh.mergeDeregistrationErrors(errors)
-	} else {
-		return nil
-	}
+	return utils.MergeErrorsOrNil(errors, "handling deregistration")
 }
 
 //This handler is used when an application is restarted and renamed
@@ -217,11 +214,7 @@ func (fh *eventHandler) handleDeploymentStepSuccess(body []byte) error {
 			errors = append(errors, err)
 		}
 	}
-	if len(errors) > 0 {
-		return fh.mergeDeregistrationErrors(errors)
-	} else {
-		return nil
-	}
+	return utils.MergeErrorsOrNil(errors, "handling deregistration")
 }
 
 func (fh *eventHandler) deregisterAllAppServices(app *apps.App) []error {
@@ -275,14 +268,6 @@ func findTaskById(id apps.TaskId, tasks_ []apps.Task) (apps.Task, error) {
 		}
 	}
 	return apps.Task{}, fmt.Errorf("Task %s not found", id)
-}
-
-func (fh *eventHandler) mergeDeregistrationErrors(errors []error) error {
-	errMessage := fmt.Sprintf("%d errors occured handling service deregistration", len(errors))
-	for i, err := range errors {
-		errMessage = fmt.Sprintf("%s\n%d: %s", errMessage, i, err.Error())
-	}
-	return fmt.Errorf(errMessage)
 }
 
 // for every other use of Tasks, Marathon uses the "id" field for the task ID.


### PR DESCRIPTION
Deregistering by task used to load all nodes (service instances) and loop over them in search for marathon task tag. With this change it loads all services and only loads nodes of services containing the marathon task tag.

It also correctly handles the corner case when there are multiple nodes containing the same marathon task id tag – it deregisters all of them. Before it would deregister only the first occurrence.