### PR TITLE
Reregistering on missing marathon-task tag during sync

### DIFF
--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -295,7 +295,7 @@ func TestSyncOnlyHealthyServices(t *testing.T) {
 	}
 }
 
-func TestSync_SkipServicesWithoutMarathonTaskTag(t *testing.T) {
+func TestSync_DeregisterServicesWithoutMarathonTaskTag(t *testing.T) {
 	t.Parallel()
 	// given
 	app := ConsulApp("app1", 1)
@@ -308,8 +308,7 @@ func TestSync_SkipServicesWithoutMarathonTaskTag(t *testing.T) {
 
 	// then
 	services, _ := consul.GetAllServices()
-	assert.Equal(t, 1, len(services))
-	assert.NotContains(t, services[0].Tags, service.MarathonTaskTag(app.Tasks[0].ID))
+	assert.Empty(t, services)
 }
 
 func TestSync_WithRegisteringProblems(t *testing.T) {


### PR DESCRIPTION
When doing sync and coming across a service without marathon-task tag we used to skip that service and leave it in the registry. This change causes the service to get deregistered, as sync's subsequent registering phase should reregister such service properly.

The service will be unavailable for a couple of seconds in this process – before its new healthchecks become passing. If that's a problem, it's advised to add marathon-task tag to all registered services before starting updated marathon-consul, e.g. using migration script from #106.