### PR TITLE
Fixes #108 Use static port number in health check

### DIFF
--- a/apps/app.go
+++ b/apps/app.go
@@ -10,6 +10,7 @@ const MARATHON_CONSUL_LABEL = "consul"
 type HealthCheck struct {
 	Path                   string `json:"path"`
 	PortIndex              int    `json:"portIndex"`
+	Port                   int    `json:"port"`
 	Protocol               string `json:"protocol"`
 	GracePeriodSeconds     int    `json:"gracePeriodSeconds"`
 	IntervalSeconds        int    `json:"intervalSeconds"`

--- a/apps/app.json
+++ b/apps/app.json
@@ -34,6 +34,16 @@
         "timeoutSeconds": 10,
         "maxConsecutiveFailures": 3,
         "ignoreHttp1xx": false
+      },
+      {
+        "path": "/custom",
+        "protocol": "HTTP",
+        "port": 8123,
+        "gracePeriodSeconds": 10,
+        "intervalSeconds": 5,
+        "timeoutSeconds": 10,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
       }
     ],
     "dependencies": [],

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -55,13 +55,26 @@ func TestParseApp(t *testing.T) {
 	appBlob, _ := ioutil.ReadFile("app.json")
 
 	expected := &App{Labels: map[string]string{"consul": "true", "public": "tag"},
-		HealthChecks: []HealthCheck{{Path: "/",
-			PortIndex:              0,
-			Protocol:               "HTTP",
-			GracePeriodSeconds:     10,
-			IntervalSeconds:        5,
-			TimeoutSeconds:         10,
-			MaxConsecutiveFailures: 3}},
+		HealthChecks: []HealthCheck{
+			{
+				Path:                   "/",
+				PortIndex:              0,
+				Protocol:               "HTTP",
+				GracePeriodSeconds:     10,
+				IntervalSeconds:        5,
+				TimeoutSeconds:         10,
+				MaxConsecutiveFailures: 3,
+			},
+			{
+				Path:                   "/custom",
+				Port:                   8123,
+				Protocol:               "HTTP",
+				GracePeriodSeconds:     10,
+				IntervalSeconds:        5,
+				TimeoutSeconds:         10,
+				MaxConsecutiveFailures: 3,
+			},
+		},
 		ID: "/myapp",
 		Tasks: []Task{{
 			ID:    "myapp.cc49ccc1-9812-11e5-a06e-56847afe9799",

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -495,7 +495,7 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 			{
 				Path:                   "/api/health?with=query",
 				Protocol:               "HTTP",
-				PortIndex:              0,
+				Port:                   8123,
 				IntervalSeconds:        60,
 				TimeoutSeconds:         20,
 				MaxConsecutiveFailures: 3,
@@ -532,6 +532,13 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 				MaxConsecutiveFailures: 3,
 			},
 			{
+				Protocol:               "TCP",
+				Port:                   8234,
+				IntervalSeconds:        40,
+				TimeoutSeconds:         20,
+				MaxConsecutiveFailures: 3,
+			},
+			{
 				Protocol: "COMMAND",
 				Command: struct {
 					Value string `json:"value"`
@@ -562,11 +569,11 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 	assert.Equal(t, []string{"marathon", "public"}, service.Tags)
 	assert.Equal(t, 8090, service.Port)
 	assert.Nil(t, service.Check)
-	assert.Equal(t, 4, len(service.Checks))
+	assert.Equal(t, 5, len(service.Checks))
 
 	assert.Equal(t, consulapi.AgentServiceChecks{
 		{
-			HTTP:     "http://127.0.0.6:8090/api/health?with=query",
+			HTTP:     "http://127.0.0.6:8123/api/health?with=query",
 			Interval: "60s",
 			Timeout:  "20s",
 		},
@@ -577,6 +584,11 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 		},
 		{
 			TCP:      "127.0.0.6:8443",
+			Interval: "40s",
+			Timeout:  "20s",
+		},
+		{
+			TCP:      "127.0.0.6:8234",
 			Interval: "40s",
 			Timeout:  "20s",
 		},


### PR DESCRIPTION
If `port` is present in health check configuration then it's used instead of `portIndex`. This allows performing health check on static ports.
Change will apply only to newly started tasks, old won't be touched.