### PR TITLE
Exclude `go-vet` and `go-test` from `goxc`

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -1,7 +1,8 @@
 {
 	"ArtifactsDest": "dist",
-	"Tasks": [
-		"default"
+	"TasksExclude": [
+		"go-vet",
+		"go-test"
 	],
 	"BuildConstraints": "linux,!arm darwin",
 	"PackageVersion": "0.4.1",


### PR DESCRIPTION
There is an [goxc issue](https://github.com/laher/goxc/issues/90) that
say there won't be workarounds for missing vendoring support in `go vet`
and `go test`. To support building with goxc with vendoring we need to
disable this two tasks.
Related to #101