### PR TITLE
Add linter and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ before_install:
   - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/alecthomas/gometalinter
 script:
   - make deps
+  - gometalinter --install
+  - gometalinter ./... --deadline 120s --vendor -D dupl -D gotype -D errcheck -D gas -D golint -E gofmt
   - go test -coverprofile=apps.coverprofile ./apps
   - go test -coverprofile=config.coverprofile ./config
   - go test -coverprofile=consul.coverprofile ./consul

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -117,11 +117,11 @@ func TestConsulApp(t *testing.T) {
 
 func TestAppId_String(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "appId", AppId("appId").String())
+	assert.Equal(t, "appId", AppID("appId").String())
 }
 
 var dummyTask = &Task{
-	ID:    TaskId("some-task"),
+	ID:    TaskID("some-task"),
 	Ports: []int{1337},
 }
 
@@ -212,10 +212,10 @@ func TestRegistrationIntent_NoOverrideViaPortDefinitionsIfNoConsulLabelThere(t *
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true", "private": "tag"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"other": "tag"},
 			},
-			PortDefinition{},
+			{},
 		},
 	}
 	task := &Task{
@@ -240,10 +240,10 @@ func TestRegistrationIntent_OverrideNameAndAddTagsViaPortDefinitions(t *testing.
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true", "private": "tag"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "other-name", "other": "tag"},
 			},
-			PortDefinition{},
+			{},
 		},
 	}
 	task := &Task{
@@ -268,8 +268,8 @@ func TestRegistrationIntent_PickDifferentPortViaPortDefinitions(t *testing.T) {
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true", "private": "tag"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{},
-			PortDefinition{
+			{},
+			{
 				Labels: map[string]string{"consul": "true"},
 			},
 		},
@@ -293,7 +293,7 @@ func TestRegistrationIntent_PickExplicitPortViaPortDefinitions(t *testing.T) {
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true", "private": "tag"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Port:   1337,
 				Labels: map[string]string{"consul": "true"},
 			},
@@ -318,10 +318,10 @@ func TestRegistrationIntent_MultipleIntentsViaPortDefinitionIfMultipleContainCon
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true", "common-tag": "tag"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "first-name", "first-tag": "tag"},
 			},
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "second-name", "second-tag": "tag"},
 			},
 		},
@@ -364,10 +364,10 @@ func TestConsulNames_WithPortDefinitions(t *testing.T) {
 		ID:     "context/app-name",
 		Labels: map[string]string{"consul": ""},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "some/name"},
 			},
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "yet-another/name"},
 			},
 		},
@@ -433,7 +433,7 @@ func TestHasSameConsulNamesAs_SameConfigsWithPortDefinitions(t *testing.T) {
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "true"},
 			},
 		},
@@ -451,7 +451,7 @@ func TestHasSameConsulNamesAs_DifferentConfigsSameNamesWithPortDefinitions(t *te
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "true"},
 			},
 		},
@@ -460,7 +460,7 @@ func TestHasSameConsulNamesAs_DifferentConfigsSameNamesWithPortDefinitions(t *te
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "app-name"},
 			},
 		},
@@ -479,7 +479,7 @@ func TestHasSameConsulNamesAs_DifferentConfigsDifferentNamesWithPortDefinitions(
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "some-name"},
 			},
 		},
@@ -488,7 +488,7 @@ func TestHasSameConsulNamesAs_DifferentConfigsDifferentNamesWithPortDefinitions(
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "other-name"},
 			},
 		},
@@ -506,7 +506,7 @@ func TestHasSameConsulNamesAs_DifferentConfigsDifferentNumberOfRegitrationsWithP
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "some-name"},
 			},
 		},
@@ -515,10 +515,10 @@ func TestHasSameConsulNamesAs_DifferentConfigsDifferentNumberOfRegitrationsWithP
 		ID:     "app-name",
 		Labels: map[string]string{"consul": "true"},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "some-name"},
 			},
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": "yet-another-name"},
 			},
 		},
@@ -545,7 +545,7 @@ func TestRegistrationIntentsNumber_NoPortDefinitions(t *testing.T) {
 
 	// given
 	app := &App{
-		ID: "id",
+		ID:     "id",
 		Labels: map[string]string{"consul": ""},
 	}
 
@@ -561,7 +561,7 @@ func TestRegistrationIntentsNumber_SinglePortDefinitions(t *testing.T) {
 		ID:     "id",
 		Labels: map[string]string{"consul": ""},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": ""},
 			},
 		},
@@ -579,10 +579,10 @@ func TestRegistrationIntentsNumber_MultiplePortDefinitions(t *testing.T) {
 		ID:     "id",
 		Labels: map[string]string{"consul": ""},
 		PortDefinitions: []PortDefinition{
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": ""},
 			},
-			PortDefinition{
+			{
 				Labels: map[string]string{"consul": ""},
 			},
 		},

--- a/apps/task.go
+++ b/apps/task.go
@@ -6,25 +6,25 @@ import (
 )
 
 type Task struct {
-	ID                 TaskId              `json:"id"`
+	ID                 TaskID              `json:"id"`
 	TaskStatus         string              `json:"taskStatus"`
-	AppID              AppId               `json:"appId"`
+	AppID              AppID               `json:"appId"`
 	Host               string              `json:"host"`
 	Ports              []int               `json:"ports"`
 	HealthCheckResults []HealthCheckResult `json:"healthCheckResults"`
 }
 
-// Marathon Task Id
+// Marathon Task ID
 // Usually in the form of AppId.uuid with '/' replaced with '_'
-type TaskId string
+type TaskID string
 
-func (id TaskId) String() string {
+func (id TaskID) String() string {
 	return string(id)
 }
 
-func (id TaskId) AppId() AppId {
+func (id TaskID) AppID() AppID {
 	index := strings.LastIndex(id.String(), ".")
-	return AppId("/" + strings.Replace(id.String()[0:index], "_", "/", -1))
+	return AppID("/" + strings.Replace(id.String()[0:index], "_", "/", -1))
 }
 
 type HealthCheckResult struct {

--- a/apps/task_test.go
+++ b/apps/task_test.go
@@ -106,16 +106,16 @@ func TestIsHealthy(t *testing.T) {
 
 func TestId_String(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "id", TaskId("id").String())
+	assert.Equal(t, "id", TaskID("id").String())
 }
 
 func TestId_AppId(t *testing.T) {
 	t.Parallel()
 	id := "pl.allegro_test_app.a7cde60e-0093-11e6-ab55-02aab772a161"
-	assert.Equal(t, AppId("/pl.allegro/test/app"), TaskId(id).AppId())
+	assert.Equal(t, AppID("/pl.allegro/test/app"), TaskID(id).AppID())
 }
 
 func TestId_AppIdForInvalid(t *testing.T) {
 	t.Parallel()
-	assert.Panics(t, func() { TaskId("id").AppId() })
+	assert.Panics(t, func() { TaskID("id").AppID() })
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Config struct {
-	Consul   consul.ConsulConfig
+	Consul   consul.Config
 	Web      web.Config
 	Sync     sync.Config
 	Marathon marathon.Config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,7 +85,7 @@ func TestConfig_ShouldUseTextFormatterWhenFormatterIsUnknown(t *testing.T) {
 func TestConfig_ShouldBeMergedWithFileDefaultsAndFlags(t *testing.T) {
 	clear()
 	expected := &Config{
-		Consul: consul.ConsulConfig{
+		Consul: consul.Config{
 			Auth: consul.Auth{Enabled: false,
 				Username: "",
 				Password: ""},

--- a/consul/agent.go
+++ b/consul/agent.go
@@ -9,10 +9,9 @@ import (
 )
 
 type Agent struct {
-	Client        *consulapi.Client
-	IP            string
-	failures      uint32
-	failureMetric string
+	Client   *consulapi.Client
+	IP       string
+	failures uint32
 }
 
 func (a *Agent) IncFailures() uint32 {

--- a/consul/agents.go
+++ b/consul/agents.go
@@ -2,7 +2,7 @@ package consul
 
 import (
 	"crypto/tls"
-	"fmt"
+	"errors"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -21,12 +21,12 @@ type Agents interface {
 
 type ConcurrentAgents struct {
 	agents map[string]*Agent
-	config *ConsulConfig
+	config *Config
 	lock   sync.Mutex
 	client *http.Client
 }
 
-func NewAgents(config *ConsulConfig) *ConcurrentAgents {
+func NewAgents(config *Config) *ConcurrentAgents {
 	client := &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -48,13 +48,13 @@ func (a *ConcurrentAgents) GetAnyAgent() (*Agent, error) {
 	defer a.lock.Unlock()
 
 	if len(a.agents) > 0 {
-		ipAddress := a.getRandomAgentIpAddress()
+		ipAddress := a.getRandomAgentIPAddress()
 		return a.agents[ipAddress], nil
 	}
-	return nil, fmt.Errorf("No Consul client available in agents cache")
+	return nil, errors.New("No Consul client available in agents cache")
 }
 
-func (a *ConcurrentAgents) getRandomAgentIpAddress() string {
+func (a *ConcurrentAgents) getRandomAgentIPAddress() string {
 	ipAddresses := []string{}
 	for ipAddress := range a.agents {
 		ipAddresses = append(ipAddresses, ipAddress)

--- a/consul/agents_test.go
+++ b/consul/agents_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetAgent(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	agent, err := agents.GetAgent("127.0.0.1")
@@ -23,7 +23,7 @@ func TestGetAgent(t *testing.T) {
 func TestGetAnyAgent_SingleAgentAvailable(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	agents.GetAgent("127.0.0.1") // create
@@ -38,7 +38,7 @@ func TestGetAnyAgent_SingleAgentAvailable(t *testing.T) {
 func TestGetAnyAgent(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 	agent1, _ := agents.GetAgent("127.0.0.1")
 	agent2, _ := agents.GetAgent("127.0.0.2")
 	agent3, _ := agents.GetAgent("127.0.0.3")
@@ -54,7 +54,7 @@ func TestGetAnyAgent(t *testing.T) {
 func TestGetAgent_ShouldResolveAddressToIP(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	agent1, _ := agents.GetAgent("127.0.0.1")
@@ -67,7 +67,7 @@ func TestGetAgent_ShouldResolveAddressToIP(t *testing.T) {
 func TestGetAgent_ShouldFailOnWrongHostname(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	_, err := agents.GetAgent("wrong hostname")
@@ -79,7 +79,7 @@ func TestGetAgent_ShouldFailOnWrongHostname(t *testing.T) {
 func TestGetAgent_ShouldFailOnUnknownHostname(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	_, err := agents.GetAgent("unknown.host.name.1")
@@ -91,7 +91,7 @@ func TestGetAgent_ShouldFailOnUnknownHostname(t *testing.T) {
 func TestGetAnyAgent_shouldFailOnNoAgentAvailable(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 
 	// when
 	anyAgent, err := agents.GetAnyAgent()
@@ -104,7 +104,7 @@ func TestGetAnyAgent_shouldFailOnNoAgentAvailable(t *testing.T) {
 func TestRemoveAgent(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 	agents.GetAgent("127.0.0.1")
 	agent2, _ := agents.GetAgent("127.0.0.2")
 
@@ -123,7 +123,7 @@ func TestRemoveAgent(t *testing.T) {
 func TestRemoveAgentTwiceShouldPass(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 	agents.GetAgent("127.0.0.1")
 
 	// when

--- a/consul/config.go
+++ b/consul/config.go
@@ -2,7 +2,7 @@ package consul
 
 import "time"
 
-type ConsulConfig struct {
+type Config struct {
 	Auth                   Auth
 	Port                   string
 	SslEnabled             bool

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -148,7 +148,7 @@ func (c *Consul) Register(task *apps.Task, app *apps.App) error {
 	if err != nil {
 		return err
 	}
-	if value, ok := app.Labels[apps.MARATHON_CONSUL_LABEL]; ok && value == "true" {
+	if value, ok := app.Labels[apps.MarathonConsulLabel]; ok && value == "true" {
 		log.WithField("Id", app.ID).Warn("Warning! Application configuration is deprecated (labeled as `consul:true`). Support for special `true` value will be removed in the future!")
 	}
 	metrics.Time("consul.register", func() { err = c.registerMultipleServices(services) })
@@ -193,7 +193,7 @@ func (c *Consul) register(service *consulapi.AgentServiceRegistration) error {
 	return err
 }
 
-func (c *Consul) DeregisterByTask(taskId apps.TaskId) error {
+func (c *Consul) DeregisterByTask(taskId apps.TaskID) error {
 	services, err := c.findServicesByTaskId(taskId)
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func (c *Consul) DeregisterByTask(taskId apps.TaskId) error {
 	return c.deregisterMultipleServices(services, taskId)
 }
 
-func (c *Consul) deregisterMultipleServices(services []*service.Service, taskId apps.TaskId) error {
+func (c *Consul) deregisterMultipleServices(services []*service.Service, taskId apps.TaskID) error {
 	var deregisterErrors []error
 	for _, s := range services {
 		deregisterErr := c.Deregister(s)
@@ -215,7 +215,7 @@ func (c *Consul) deregisterMultipleServices(services []*service.Service, taskId 
 	return utils.MergeErrorsOrNil(deregisterErrors, fmt.Sprintf("deregistering by task %s", taskId))
 }
 
-func (c *Consul) findServicesByTaskId(searchedTaskId apps.TaskId) ([]*service.Service, error) {
+func (c *Consul) findServicesByTaskId(searchedTaskId apps.TaskID) ([]*service.Service, error) {
 	return c.getServicesUsingProviderWithRetriesOnAgentFailure(func(agent *consulapi.Client) ([]*service.Service, error) {
 		dcAwareQueries, err := dcAwareQueriesForAllDCs(agent)
 		if err != nil {

--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -9,31 +9,31 @@ import (
 )
 
 // TODO this should be a service registry stub in the service package, requires abstracting from AgentServiceRegistration
-type ConsulStub struct {
+type Stub struct {
 	services                   map[service.ServiceId]*consulapi.AgentServiceRegistration
 	failGetServicesForNames    map[string]bool
-	failRegisterForIds         map[apps.TaskID]bool
-	failDeregisterByTaskForIds map[apps.TaskID]bool
-	failDeregisterForIds       map[service.ServiceId]bool
+	failRegisterForIDs         map[apps.TaskID]bool
+	failDeregisterByTaskForIDs map[apps.TaskID]bool
+	failDeregisterForIDs       map[service.ServiceId]bool
 	consul                     *Consul
 }
 
-func NewConsulStub() *ConsulStub {
+func NewConsulStub() *Stub {
 	return NewConsulStubWithTag("marathon")
 }
 
-func NewConsulStubWithTag(tag string) *ConsulStub {
-	return &ConsulStub{
+func NewConsulStubWithTag(tag string) *Stub {
+	return &Stub{
 		services:                   make(map[service.ServiceId]*consulapi.AgentServiceRegistration),
 		failGetServicesForNames:    make(map[string]bool),
-		failRegisterForIds:         make(map[apps.TaskID]bool),
-		failDeregisterByTaskForIds: make(map[apps.TaskID]bool),
-		failDeregisterForIds:       make(map[service.ServiceId]bool),
-		consul:                     New(ConsulConfig{Tag: tag, ConsulNameSeparator: "."}),
+		failRegisterForIDs:         make(map[apps.TaskID]bool),
+		failDeregisterByTaskForIDs: make(map[apps.TaskID]bool),
+		failDeregisterForIDs:       make(map[service.ServiceId]bool),
+		consul:                     New(Config{Tag: tag, ConsulNameSeparator: "."}),
 	}
 }
 
-func (c ConsulStub) GetAllServices() ([]*service.Service, error) {
+func (c Stub) GetAllServices() ([]*service.Service, error) {
 	var allServices []*service.Service
 	for _, s := range c.services {
 		allServices = append(allServices, &service.Service{
@@ -46,23 +46,23 @@ func (c ConsulStub) GetAllServices() ([]*service.Service, error) {
 	return allServices, nil
 }
 
-func (c ConsulStub) FailGetServicesForName(failOnName string) {
+func (c Stub) FailGetServicesForName(failOnName string) {
 	c.failGetServicesForNames[failOnName] = true
 }
 
-func (c ConsulStub) FailRegisterForId(taskId apps.TaskID) {
-	c.failRegisterForIds[taskId] = true
+func (c Stub) FailRegisterForID(taskID apps.TaskID) {
+	c.failRegisterForIDs[taskID] = true
 }
 
-func (c ConsulStub) FailDeregisterByTaskForId(taskId apps.TaskID) {
-	c.failDeregisterByTaskForIds[taskId] = true
+func (c Stub) FailDeregisterByTaskForID(taskID apps.TaskID) {
+	c.failDeregisterByTaskForIDs[taskID] = true
 }
 
-func (c ConsulStub) FailDeregisterForId(serviceId service.ServiceId) {
-	c.failDeregisterForIds[serviceId] = true
+func (c Stub) FailDeregisterForID(serviceID service.ServiceId) {
+	c.failDeregisterForIDs[serviceID] = true
 }
 
-func (c ConsulStub) GetServices(name string) ([]*service.Service, error) {
+func (c Stub) GetServices(name string) ([]*service.Service, error) {
 	if _, ok := c.failGetServicesForNames[name]; ok {
 		return nil, fmt.Errorf("Consul stub programmed to fail when getting services for name %s", name)
 	}
@@ -80,22 +80,21 @@ func (c ConsulStub) GetServices(name string) ([]*service.Service, error) {
 	return services, nil
 }
 
-func (c *ConsulStub) Register(task *apps.Task, app *apps.App) error {
-	if _, ok := c.failRegisterForIds[task.ID]; ok {
+func (c *Stub) Register(task *apps.Task, app *apps.App) error {
+	if _, ok := c.failRegisterForIDs[task.ID]; ok {
 		return fmt.Errorf("Consul stub programmed to fail when registering task of id %s", task.ID.String())
-	} else {
-		serviceRegistrations, err := c.consul.marathonTaskToConsulServices(task, app)
-		if err != nil {
-			return err
-		}
-		for _, r := range serviceRegistrations {
-			c.services[service.ServiceId(r.ID)] = r
-		}
-		return nil
 	}
+	serviceRegistrations, err := c.consul.marathonTaskToConsulServices(task, app)
+	if err != nil {
+		return err
+	}
+	for _, r := range serviceRegistrations {
+		c.services[service.ServiceId(r.ID)] = r
+	}
+	return nil
 }
 
-func (c *ConsulStub) RegisterWithoutMarathonTaskTag(task *apps.Task, app *apps.App) {
+func (c *Stub) RegisterWithoutMarathonTaskTag(task *apps.Task, app *apps.App) {
 	for _, intent := range app.RegistrationIntents(task, c.consul.config.ConsulNameSeparator) {
 		serviceRegistration := consulapi.AgentServiceRegistration{
 			ID:      task.ID.String(),
@@ -109,50 +108,49 @@ func (c *ConsulStub) RegisterWithoutMarathonTaskTag(task *apps.Task, app *apps.A
 	}
 }
 
-func (c *ConsulStub) RegisterOnlyFirstRegistrationIntent(task *apps.Task, app *apps.App) {
+func (c *Stub) RegisterOnlyFirstRegistrationIntent(task *apps.Task, app *apps.App) {
 	serviceRegistrations, _ := c.consul.marathonTaskToConsulServices(task, app)
 	c.services[service.ServiceId(serviceRegistrations[0].ID)] = serviceRegistrations[0]
 }
 
-func (c *ConsulStub) ServiceNames(app *apps.App) []string {
+func (c *Stub) ServiceNames(app *apps.App) []string {
 	return c.consul.ServiceNames(app)
 }
 
-func (c *ConsulStub) DeregisterByTask(taskId apps.TaskID) error {
-	if _, ok := c.failDeregisterByTaskForIds[taskId]; ok {
-		return fmt.Errorf("Consul stub programmed to fail when deregistering task of id %s", taskId.String())
-	} else {
-		for _, x := range c.servicesMatchingTask(c.services, taskId) {
-			delete(c.services, service.ServiceId(x.ID))
-		}
-		return nil
+func (c *Stub) DeregisterByTask(taskID apps.TaskID) error {
+	if _, ok := c.failDeregisterByTaskForIDs[taskID]; ok {
+		return fmt.Errorf("Consul stub programmed to fail when deregistering task of id %s", taskID.String())
 	}
+	for _, x := range c.servicesMatchingTask(taskID) {
+		delete(c.services, service.ServiceId(x.ID))
+	}
+	return nil
 }
 
-func (c *ConsulStub) Deregister(toDeregister *service.Service) error {
-	if _, ok := c.failDeregisterForIds[toDeregister.ID]; ok {
+func (c *Stub) Deregister(toDeregister *service.Service) error {
+	if _, ok := c.failDeregisterForIDs[toDeregister.ID]; ok {
 		return fmt.Errorf("Consul stub programmed to fail when deregistering service of id %s", toDeregister.ID)
 	}
 	delete(c.services, toDeregister.ID)
 	return nil
 }
 
-func (c *ConsulStub) servicesMatchingTask(services map[service.ServiceId]*consulapi.AgentServiceRegistration, taskId apps.TaskID) []*consulapi.AgentServiceRegistration {
+func (c *Stub) servicesMatchingTask(taskID apps.TaskID) []*consulapi.AgentServiceRegistration {
 	matching := []*consulapi.AgentServiceRegistration{}
-	for _, s := range services {
-		if s.ID == taskId.String() || contains(s.Tags, fmt.Sprintf("marathon-task:%s", taskId.String())) {
+	for _, s := range c.services {
+		if s.ID == taskID.String() || contains(s.Tags, fmt.Sprintf("marathon-task:%s", taskID.String())) {
 			matching = append(matching, s)
 		}
 	}
 	return matching
 }
 
-func (c *ConsulStub) RegisteredTaskIds() []apps.TaskID {
+func (c *Stub) RegisteredTaskIDs() []apps.TaskID {
 	services, _ := c.GetAllServices()
 	taskIds := []apps.TaskID{}
 	for _, s := range services {
-		taskId, _ := s.TaskId()
-		taskIds = append(taskIds, taskId)
+		taskID, _ := s.TaskId()
+		taskIds = append(taskIds, taskID)
 	}
 	return taskIds
 }

--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -12,8 +12,8 @@ import (
 type ConsulStub struct {
 	services                   map[service.ServiceId]*consulapi.AgentServiceRegistration
 	failGetServicesForNames    map[string]bool
-	failRegisterForIds         map[apps.TaskId]bool
-	failDeregisterByTaskForIds map[apps.TaskId]bool
+	failRegisterForIds         map[apps.TaskID]bool
+	failDeregisterByTaskForIds map[apps.TaskID]bool
 	failDeregisterForIds       map[service.ServiceId]bool
 	consul                     *Consul
 }
@@ -26,8 +26,8 @@ func NewConsulStubWithTag(tag string) *ConsulStub {
 	return &ConsulStub{
 		services:                   make(map[service.ServiceId]*consulapi.AgentServiceRegistration),
 		failGetServicesForNames:    make(map[string]bool),
-		failRegisterForIds:         make(map[apps.TaskId]bool),
-		failDeregisterByTaskForIds: make(map[apps.TaskId]bool),
+		failRegisterForIds:         make(map[apps.TaskID]bool),
+		failDeregisterByTaskForIds: make(map[apps.TaskID]bool),
 		failDeregisterForIds:       make(map[service.ServiceId]bool),
 		consul:                     New(ConsulConfig{Tag: tag, ConsulNameSeparator: "."}),
 	}
@@ -40,7 +40,7 @@ func (c ConsulStub) GetAllServices() ([]*service.Service, error) {
 			ID:   service.ServiceId(s.ID),
 			Name: s.Name,
 			RegisteringAgentAddress: s.Address,
-			Tags: s.Tags,
+			Tags:                    s.Tags,
 		})
 	}
 	return allServices, nil
@@ -50,11 +50,11 @@ func (c ConsulStub) FailGetServicesForName(failOnName string) {
 	c.failGetServicesForNames[failOnName] = true
 }
 
-func (c ConsulStub) FailRegisterForId(taskId apps.TaskId) {
+func (c ConsulStub) FailRegisterForId(taskId apps.TaskID) {
 	c.failRegisterForIds[taskId] = true
 }
 
-func (c ConsulStub) FailDeregisterByTaskForId(taskId apps.TaskId) {
+func (c ConsulStub) FailDeregisterByTaskForId(taskId apps.TaskID) {
 	c.failDeregisterByTaskForIds[taskId] = true
 }
 
@@ -73,7 +73,7 @@ func (c ConsulStub) GetServices(name string) ([]*service.Service, error) {
 				ID:   service.ServiceId(s.ID),
 				Name: s.Name,
 				RegisteringAgentAddress: s.Address,
-				Tags: s.Tags,
+				Tags:                    s.Tags,
 			})
 		}
 	}
@@ -118,7 +118,7 @@ func (c *ConsulStub) ServiceNames(app *apps.App) []string {
 	return c.consul.ServiceNames(app)
 }
 
-func (c *ConsulStub) DeregisterByTask(taskId apps.TaskId) error {
+func (c *ConsulStub) DeregisterByTask(taskId apps.TaskID) error {
 	if _, ok := c.failDeregisterByTaskForIds[taskId]; ok {
 		return fmt.Errorf("Consul stub programmed to fail when deregistering task of id %s", taskId.String())
 	} else {
@@ -137,7 +137,7 @@ func (c *ConsulStub) Deregister(toDeregister *service.Service) error {
 	return nil
 }
 
-func (c *ConsulStub) servicesMatchingTask(services map[service.ServiceId]*consulapi.AgentServiceRegistration, taskId apps.TaskId) []*consulapi.AgentServiceRegistration {
+func (c *ConsulStub) servicesMatchingTask(services map[service.ServiceId]*consulapi.AgentServiceRegistration, taskId apps.TaskID) []*consulapi.AgentServiceRegistration {
 	matching := []*consulapi.AgentServiceRegistration{}
 	for _, s := range services {
 		if s.ID == taskId.String() || contains(s.Tags, fmt.Sprintf("marathon-task:%s", taskId.String())) {
@@ -147,9 +147,9 @@ func (c *ConsulStub) servicesMatchingTask(services map[service.ServiceId]*consul
 	return matching
 }
 
-func (c *ConsulStub) RegisteredTaskIds() []apps.TaskId {
+func (c *ConsulStub) RegisteredTaskIds() []apps.TaskID {
 	services, _ := c.GetAllServices()
-	taskIds := []apps.TaskId{}
+	taskIds := []apps.TaskID{}
 	for _, s := range services {
 		taskId, _ := s.TaskId()
 		taskIds = append(taskIds, taskId)

--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -39,8 +39,8 @@ func (c Stub) GetAllServices() ([]*service.Service, error) {
 		allServices = append(allServices, &service.Service{
 			ID:   service.ServiceId(s.ID),
 			Name: s.Name,
+			Tags: s.Tags,
 			RegisteringAgentAddress: s.Address,
-			Tags:                    s.Tags,
 		})
 	}
 	return allServices, nil
@@ -72,8 +72,8 @@ func (c Stub) GetServices(name string) ([]*service.Service, error) {
 			services = append(services, &service.Service{
 				ID:   service.ServiceId(s.ID),
 				Name: s.Name,
+				Tags: s.Tags,
 				RegisteringAgentAddress: s.Address,
-				Tags:                    s.Tags,
 			})
 		}
 	}

--- a/consul/consul_stub_test.go
+++ b/consul/consul_stub_test.go
@@ -39,7 +39,7 @@ func TestConsulStub(t *testing.T) {
 	// when
 	err = consul.DeregisterByTask(app.Tasks[1].ID)
 	services, _ = consul.GetAllServices()
-	taskIds := consul.RegisteredTaskIds()
+	taskIds := consul.RegisteredTaskIDs()
 
 	// then
 	assert.NoError(t, err)
@@ -48,7 +48,7 @@ func TestConsulStub(t *testing.T) {
 	assert.Contains(t, taskIds, apps.TaskID("test.2"))
 
 	// given
-	consul.FailDeregisterByTaskForId(app.Tasks[0].ID)
+	consul.FailDeregisterByTaskForID(app.Tasks[0].ID)
 
 	// when
 	err = consul.DeregisterByTask(app.Tasks[0].ID)
@@ -70,7 +70,7 @@ func TestConsulStub(t *testing.T) {
 
 	// then
 	assert.NoError(t, err)
-	assert.Len(t, consul.RegisteredTaskIds(), 1)
+	assert.Len(t, consul.RegisteredTaskIDs(), 1)
 
 	// when
 	app = utils.ConsulApp("other", 2)

--- a/consul/consul_stub_test.go
+++ b/consul/consul_stub_test.go
@@ -44,8 +44,8 @@ func TestConsulStub(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Len(t, services, 2)
-	assert.Contains(t, taskIds, apps.TaskId("test.0"))
-	assert.Contains(t, taskIds, apps.TaskId("test.2"))
+	assert.Contains(t, taskIds, apps.TaskID("test.0"))
+	assert.Contains(t, taskIds, apps.TaskID("test.2"))
 
 	// given
 	consul.FailDeregisterByTaskForId(app.Tasks[0].ID)

--- a/consul/consul_stub_test.go
+++ b/consul/consul_stub_test.go
@@ -57,7 +57,7 @@ func TestConsulStub(t *testing.T) {
 	assert.Error(t, err)
 
 	// given
-	consul.FailRegisterForId(app.Tasks[0].ID)
+	consul.FailRegisterForID(app.Tasks[0].ID)
 
 	// when
 	err = consul.Register(&app.Tasks[0], app)

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -396,10 +396,10 @@ func TestRegisterServices_MultipleRegistrations(t *testing.T) {
 	// given
 	app := utils.ConsulApp("serviceA", 1)
 	app.PortDefinitions = []apps.PortDefinition{
-		apps.PortDefinition{
+		{
 			Labels: map[string]string{"consul": "first-name", "first-tag": "tag"},
 		},
-		apps.PortDefinition{
+		{
 			Labels: map[string]string{"consul": "second-name", "second-tag": "tag"},
 		},
 	}
@@ -557,7 +557,7 @@ func TestDeregisterServicesByTask(t *testing.T) {
 	task := app.Tasks[0]
 
 	server.AddService("serviceA", "passing", []string{"marathon", service.MarathonTaskTag(task.ID)})
-	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskId("other"))})
+	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskID("other"))})
 	services, _ := consul.GetAllServices()
 	assert.Len(t, services, 2)
 
@@ -604,7 +604,7 @@ func TestDeregisterServicesByTask_shouldReturnErrorOnServiceMatchingTaskNotFound
 	task := app.Tasks[0]
 
 	server.AddService("serviceA", "passing", []string{"marathon", service.MarathonTaskTag(task.ID)})
-	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskId("other"))})
+	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskID("other"))})
 	services, _ := consul.GetAllServices()
 	assert.Len(t, services, 2)
 
@@ -631,7 +631,7 @@ func TestDeregisterServicesByTask_shouldDeregisterAllMatchingServicesWhenMultipl
 
 	server.AddService("serviceA", "passing", []string{"marathon", service.MarathonTaskTag(task.ID)})
 	server.AddService("serviceA-bis", "passing", []string{"marathon", service.MarathonTaskTag(task.ID)})
-	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskId("other"))})
+	server.AddService("serviceB", "passing", []string{"marathon", service.MarathonTaskTag(apps.TaskID("other"))})
 	services, _ := consul.GetAllServices()
 	assert.Len(t, services, 3)
 

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetAgent_WithEmptyHost(t *testing.T) {
 	t.Parallel()
 	// given
-	agents := NewAgents(&ConsulConfig{})
+	agents := NewAgents(&Config{})
 	// when
 	agent, err := agents.GetAgent("")
 	// then
@@ -27,7 +27,7 @@ func TestGetAgent_FullConfig(t *testing.T) {
 	t.Parallel()
 
 	// given
-	agents := NewAgents(&ConsulConfig{Token: "token", SslEnabled: true,
+	agents := NewAgents(&Config{Token: "token", SslEnabled: true,
 		Auth: Auth{Enabled: true, Username: "", Password: ""}, Timeout: time.Second})
 
 	// when
@@ -42,7 +42,7 @@ func TestGetAllServices_ForEmptyAgents(t *testing.T) {
 	t.Parallel()
 
 	// given
-	consul := New(ConsulConfig{})
+	consul := New(Config{})
 
 	// when
 	services, err := consul.GetAllServices()
@@ -56,7 +56,7 @@ func TestRegister_ForInvalidHost(t *testing.T) {
 	t.Parallel()
 
 	// given
-	consul := New(ConsulConfig{})
+	consul := New(Config{})
 	app := utils.ConsulApp("serviceA", 1)
 
 	// when
@@ -80,16 +80,16 @@ func TestRegister_ForInvalidHost(t *testing.T) {
 func TestGetServices(t *testing.T) {
 	t.Parallel()
 	// create cluster of 2 consul servers
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
-	server2 := CreateConsulTestServer(t)
+	server2 := CreateTestServer(t)
 	defer server2.Stop()
 
 	server1.JoinWAN(server2.LANAddr)
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -118,11 +118,11 @@ func TestGetServices(t *testing.T) {
 
 func TestGetService_FailingAgent_GivingUp(t *testing.T) {
 	t.Parallel()
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
 	// create client
-	consul := FailingConsulClient()
+	consul := FailingClient()
 
 	// when
 	services, err := consul.GetServices("serviceA")
@@ -135,11 +135,11 @@ func TestGetService_FailingAgent_GivingUp(t *testing.T) {
 func TestGetServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 	t.Parallel()
 	// create server
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
 	consul.config.RequestRetries = 100
 
@@ -163,16 +163,16 @@ func TestGetServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 func TestGetServices_SelectOnlyTaggedServices(t *testing.T) {
 	t.Parallel()
 	// create cluster of 2 consul servers
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
-	server2 := CreateConsulTestServer(t)
+	server2 := CreateTestServer(t)
 	defer server2.Stop()
 
 	server1.JoinWAN(server2.LANAddr)
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon-mycluster"
 
 	// given
@@ -203,16 +203,16 @@ func TestGetServices_SelectOnlyTaggedServices(t *testing.T) {
 func TestGetAllServices(t *testing.T) {
 	t.Parallel()
 	// create cluster of 2 consul servers
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
-	server2 := CreateConsulTestServer(t)
+	server2 := CreateTestServer(t)
 	defer server2.Stop()
 
 	server1.JoinWAN(server2.LANAddr)
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -242,11 +242,11 @@ func TestGetAllServices(t *testing.T) {
 
 func TestGetServicesUsingProviderWithRetriesOnAgentFailure_ShouldRetryConfiguredNumberOfTimes(t *testing.T) {
 	t.Parallel()
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.AgentFailuresTolerance = 2
 	consul.config.RequestRetries = 4
 
@@ -269,11 +269,11 @@ func TestGetServicesUsingProviderWithRetriesOnAgentFailure_ShouldRetryConfigured
 
 func TestGetAllServices_FailingAgent_GivingUp(t *testing.T) {
 	t.Parallel()
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
 	// create client
-	consul := FailingConsulClient()
+	consul := FailingClient()
 
 	// when
 	services, err := consul.GetAllServices()
@@ -286,16 +286,16 @@ func TestGetAllServices_FailingAgent_GivingUp(t *testing.T) {
 func TestGetAllServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 	t.Parallel()
 	// create cluster of 2 consul servers
-	server1 := CreateConsulTestServer(t)
+	server1 := CreateTestServer(t)
 	defer server1.Stop()
 
-	server2 := CreateConsulTestServer(t)
+	server2 := CreateTestServer(t)
 	defer server2.Stop()
 
 	server1.JoinWAN(server2.LANAddr)
 
 	// create client
-	consul := ConsulClientAtServer(server1)
+	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
 	consul.config.RequestRetries = 100
 
@@ -331,10 +331,10 @@ func TestGetAllServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 
 func TestRegisterServices(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -359,10 +359,10 @@ func TestRegisterServices(t *testing.T) {
 
 func TestRegisterServices_CustomServiceName(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -387,10 +387,10 @@ func TestRegisterServices_CustomServiceName(t *testing.T) {
 
 func TestRegisterServices_MultipleRegistrations(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -441,10 +441,10 @@ func findServiceByName(name string, services []*service.Service) (*service.Servi
 
 func TestRegisterServices_InvalidHostnameShouldFail(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -461,10 +461,10 @@ func TestRegisterServices_InvalidHostnameShouldFail(t *testing.T) {
 
 func TestRegisterServices_InvalidCustomServiceName(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -491,7 +491,7 @@ func TestRegisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 	t.Parallel()
 
 	// given
-	consul := New(ConsulConfig{Port: "1234"})
+	consul := New(Config{Port: "1234"})
 	app := utils.ConsulApp("serviceA", 1)
 
 	// when
@@ -503,10 +503,10 @@ func TestRegisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 
 func TestDeregisterServices(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -527,9 +527,9 @@ func TestDeregisterServices(t *testing.T) {
 
 func TestDeregisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -546,10 +546,10 @@ func TestDeregisterServices_shouldReturnErrorOnFailure(t *testing.T) {
 
 func TestDeregisterServicesByTask(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -572,9 +572,9 @@ func TestDeregisterServicesByTask(t *testing.T) {
 
 func TestDeregisterServicesByTask_shouldReturnErrorOnFailure(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -593,10 +593,10 @@ func TestDeregisterServicesByTask_shouldReturnErrorOnFailure(t *testing.T) {
 
 func TestDeregisterServicesByTask_shouldReturnErrorOnServiceMatchingTaskNotFound(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -619,10 +619,10 @@ func TestDeregisterServicesByTask_shouldReturnErrorOnServiceMatchingTaskNotFound
 
 func TestDeregisterServicesByTask_shouldDeregisterAllMatchingServicesWhenMultipleMatchGivenTaskId(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
-	consul := ConsulClientAtServer(server)
+	consul := ClientAtServer(server)
 	consul.config.Tag = "marathon"
 
 	// given
@@ -646,11 +646,11 @@ func TestDeregisterServicesByTask_shouldDeregisterAllMatchingServicesWhenMultipl
 
 func TestAddAgentsFromApp(t *testing.T) {
 	t.Parallel()
-	server := CreateConsulTestServer(t)
+	server := CreateTestServer(t)
 	defer server.Stop()
 
 	// create consul without any agents in cache
-	consul := New(ConsulConfig{
+	consul := New(Config{
 		Timeout:             10 * time.Millisecond,
 		Port:                fmt.Sprintf("%d", server.Config.Ports.HTTP),
 		ConsulNameSeparator: ".",
@@ -675,7 +675,7 @@ func TestMarathonTaskToConsulServiceMapping(t *testing.T) {
 	t.Parallel()
 
 	// given
-	consul := New(ConsulConfig{Tag: "marathon"})
+	consul := New(Config{Tag: "marathon"})
 	app := &apps.App{
 		ID: "someApp",
 		HealthChecks: []apps.HealthCheck{
@@ -780,7 +780,7 @@ func TestMarathonTaskToConsulServiceMapping_NotResolvableTaskHost(t *testing.T) 
 	t.Parallel()
 
 	// given
-	consul := New(ConsulConfig{Tag: "marathon"})
+	consul := New(Config{Tag: "marathon"})
 	app := &apps.App{
 		ID: "someApp",
 		HealthChecks: []apps.HealthCheck{

--- a/events/deployment_info.go
+++ b/events/deployment_info.go
@@ -19,7 +19,7 @@ type Plan struct {
 }
 
 type Deployments struct {
-	Id     string         `json:"id"`
+	ID     string         `json:"id"`
 	Apps   []*apps.App    `json:"apps"`
 	Groups []*Deployments `json:"groups"`
 }
@@ -30,7 +30,7 @@ type CurrentStep struct {
 
 type Action struct {
 	Type  string     `json:"type"`
-	AppId apps.AppID `json:"app"`
+	AppID apps.AppID `json:"app"`
 }
 
 func (d *Deployments) groups() []*Deployments {
@@ -114,7 +114,7 @@ func (d *DeploymentEvent) consulAppsWithActionPerformed(deployments *Deployments
 
 	for _, action := range d.actions() {
 		if action.Type == actionType {
-			appIds[action.AppId] = exists
+			appIds[action.AppID] = exists
 		}
 	}
 	return d.filterConsulApps(d.findAppsInDeploymentsGroup(appIds, deployments))
@@ -183,9 +183,9 @@ func (d *Deployments) filterCurrentGroupAppIds(appIds map[apps.AppID]struct{}) m
 	filteredAppIds := make(map[apps.AppID]struct{})
 	var exists struct{}
 
-	for appId := range appIds {
-		if strings.HasPrefix(appId.String(), d.Id) {
-			filteredAppIds[appId] = exists
+	for appID := range appIds {
+		if strings.HasPrefix(appID.String(), d.ID) {
+			filteredAppIds[appID] = exists
 		}
 	}
 	return filteredAppIds

--- a/events/deployment_info.go
+++ b/events/deployment_info.go
@@ -30,7 +30,7 @@ type CurrentStep struct {
 
 type Action struct {
 	Type  string     `json:"type"`
-	AppId apps.AppId `json:"app"`
+	AppId apps.AppID `json:"app"`
 }
 
 func (d *Deployments) groups() []*Deployments {
@@ -100,8 +100,8 @@ func (d *DeploymentEvent) RenamedConsulApps() []*apps.App {
 	return renamedApps
 }
 
-func (d *DeploymentEvent) appsMap(applications []*apps.App) map[apps.AppId]*apps.App {
-	result := make(map[apps.AppId]*apps.App)
+func (d *DeploymentEvent) appsMap(applications []*apps.App) map[apps.AppID]*apps.App {
+	result := make(map[apps.AppID]*apps.App)
 	for _, app := range applications {
 		result[app.ID] = app
 	}
@@ -109,7 +109,7 @@ func (d *DeploymentEvent) appsMap(applications []*apps.App) map[apps.AppId]*apps
 }
 
 func (d *DeploymentEvent) consulAppsWithActionPerformed(deployments *Deployments, actionType string) []*apps.App {
-	appIds := make(map[apps.AppId]struct{})
+	appIds := make(map[apps.AppID]struct{})
 	var exists struct{}
 
 	for _, action := range d.actions() {
@@ -130,7 +130,7 @@ func (d *DeploymentEvent) filterConsulApps(allApps []*apps.App) []*apps.App {
 	return filtered
 }
 
-func (d *DeploymentEvent) findAppsInDeploymentsGroup(appIds map[apps.AppId]struct{}, deployment *Deployments) []*apps.App {
+func (d *DeploymentEvent) findAppsInDeploymentsGroup(appIds map[apps.AppID]struct{}, deployment *Deployments) []*apps.App {
 	foundApps := []*apps.App{}
 	filteredAppIds := deployment.filterCurrentGroupAppIds(appIds)
 
@@ -146,7 +146,7 @@ func (d *DeploymentEvent) findAppsInDeploymentsGroup(appIds map[apps.AppId]struc
 	return foundApps
 }
 
-func (d *DeploymentEvent) findAppsInCurrentDeploymentGroupApps(appIds map[apps.AppId]struct{}, deployment *Deployments) []*apps.App {
+func (d *DeploymentEvent) findAppsInCurrentDeploymentGroupApps(appIds map[apps.AppID]struct{}, deployment *Deployments) []*apps.App {
 	foundApps := []*apps.App{}
 	searchForCount := len(appIds)
 
@@ -162,7 +162,7 @@ func (d *DeploymentEvent) findAppsInCurrentDeploymentGroupApps(appIds map[apps.A
 	return foundApps
 }
 
-func (d *DeploymentEvent) findAppsInDeploymentChildGroups(appIds map[apps.AppId]struct{}, deployment *Deployments) []*apps.App {
+func (d *DeploymentEvent) findAppsInDeploymentChildGroups(appIds map[apps.AppID]struct{}, deployment *Deployments) []*apps.App {
 	foundApps := []*apps.App{}
 	searchForCount := len(appIds)
 
@@ -179,8 +179,8 @@ func (d *DeploymentEvent) findAppsInDeploymentChildGroups(appIds map[apps.AppId]
 	return foundApps
 }
 
-func (d *Deployments) filterCurrentGroupAppIds(appIds map[apps.AppId]struct{}) map[apps.AppId]struct{} {
-	filteredAppIds := make(map[apps.AppId]struct{})
+func (d *Deployments) filterCurrentGroupAppIds(appIds map[apps.AppID]struct{}) map[apps.AppID]struct{} {
+	filteredAppIds := make(map[apps.AppID]struct{})
 	var exists struct{}
 
 	for appId := range appIds {

--- a/events/deployment_info.go
+++ b/events/deployment_info.go
@@ -133,16 +133,10 @@ func (d *DeploymentEvent) filterConsulApps(allApps []*apps.App) []*apps.App {
 func (d *DeploymentEvent) findAppsInDeploymentsGroup(appIds map[apps.AppID]struct{}, deployment *Deployments) []*apps.App {
 	foundApps := []*apps.App{}
 	filteredAppIds := deployment.filterCurrentGroupAppIds(appIds)
-
 	foundInCurrentGroup := d.findAppsInCurrentDeploymentGroupApps(filteredAppIds, deployment)
-	for _, app := range foundInCurrentGroup {
-		foundApps = append(foundApps, app)
-	}
-
+	foundApps = append(foundApps, foundInCurrentGroup...)
 	foundInChildGroups := d.findAppsInDeploymentChildGroups(filteredAppIds, deployment)
-	for _, app := range foundInChildGroups {
-		foundApps = append(foundApps, app)
-	}
+	foundApps = append(foundApps, foundInChildGroups...)
 	return foundApps
 }
 
@@ -171,9 +165,7 @@ func (d *DeploymentEvent) findAppsInDeploymentChildGroups(appIds map[apps.AppID]
 			break
 		}
 		foundInChildGroup := d.findAppsInDeploymentsGroup(appIds, group)
-		for _, app := range foundInChildGroup {
-			foundApps = append(foundApps, app)
-		}
+		foundApps = append(foundApps, foundInChildGroup...)
 		searchForCount -= len(foundInChildGroup)
 	}
 	return foundApps

--- a/events/deployment_info_test.go
+++ b/events/deployment_info_test.go
@@ -21,7 +21,7 @@ func TestParseDeploymentInfo(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, "StopApplication", action.Type)
-	assert.Equal(t, "/internalName", action.AppId.String())
+	assert.Equal(t, "/internalName", action.AppID.String())
 	assert.Equal(t, "/internalName", app.ID.String())
 	assert.Equal(t, "consulName", app.Labels["consul"])
 }
@@ -39,7 +39,7 @@ func TestParseDeploymentStepSuccess(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, "RestartApplication", action.Type)
-	assert.Equal(t, "/a", action.AppId.String())
+	assert.Equal(t, "/a", action.AppID.String())
 	assert.Equal(t, "/a", app.ID.String())
 	assert.Equal(t, "b", app.Labels["consul"])
 }
@@ -57,7 +57,7 @@ func TestParseDeploymentStepSuccessWithGroups(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, "RestartApplication", action.Type)
-	assert.Equal(t, "/com.example/things/something", action.AppId.String())
+	assert.Equal(t, "/com.example/things/something", action.AppID.String())
 	assert.Equal(t, "/com.example/things/something", app.ID.String())
 	assert.Equal(t, "something", app.Labels["consul"])
 }
@@ -114,10 +114,10 @@ func TestStoppedConsulApps(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "StartApplication", AppId: "app1"},
-				{Type: "StopApplication", AppId: "app2"},
-				{Type: "StopApplication", AppId: "app3"},
-				{Type: "StopApplication", AppId: "app4"},
+				{Type: "StartApplication", AppID: "app1"},
+				{Type: "StopApplication", AppID: "app2"},
+				{Type: "StopApplication", AppID: "app3"},
+				{Type: "StopApplication", AppID: "app4"},
 			},
 		},
 	}
@@ -147,10 +147,10 @@ func TestRestartedConsulApps(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "StartApplication", AppId: "app1"},
-				{Type: "RestartApplication", AppId: "app2"},
-				{Type: "RestartApplication", AppId: "app3"},
-				{Type: "RestartApplication", AppId: "app4"},
+				{Type: "StartApplication", AppID: "app1"},
+				{Type: "RestartApplication", AppID: "app2"},
+				{Type: "RestartApplication", AppID: "app3"},
+				{Type: "RestartApplication", AppID: "app4"},
 			},
 		},
 	}
@@ -177,7 +177,7 @@ func TestStoppedConsulApps_NoStoppedApps(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "StartApplication", AppId: "app1"},
+				{Type: "StartApplication", AppID: "app1"},
 			},
 		},
 	}
@@ -223,9 +223,9 @@ func TestRenamedConsulApps(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app1"},
-				{Type: "StartApplication", AppId: "app2"},
-				{Type: "RestartApplication", AppId: "app3"},
+				{Type: "RestartApplication", AppID: "app1"},
+				{Type: "StartApplication", AppID: "app2"},
+				{Type: "RestartApplication", AppID: "app3"},
 			},
 		},
 	}
@@ -244,9 +244,9 @@ func TestRenamedConsulApps_OnEmptyPlan(t *testing.T) {
 	deploymentInfo := &DeploymentEvent{
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app2"},
-				{Type: "StartApplication", AppId: "app1"},
-				{Type: "RestartApplication", AppId: "app3"},
+				{Type: "RestartApplication", AppID: "app2"},
+				{Type: "StartApplication", AppID: "app1"},
+				{Type: "RestartApplication", AppID: "app3"},
 			},
 		},
 	}
@@ -278,8 +278,8 @@ func TestRenamedConsulApps_OnConsulTrueCase(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app1"},
-				{Type: "RestartApplication", AppId: "app2"},
+				{Type: "RestartApplication", AppID: "app1"},
+				{Type: "RestartApplication", AppID: "app2"},
 			},
 		},
 	}
@@ -311,8 +311,8 @@ func TestRenamedConsulApps_OnCustomNameAdded(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app1"},
-				{Type: "StartApplication", AppId: "app2"},
+				{Type: "RestartApplication", AppID: "app1"},
+				{Type: "StartApplication", AppID: "app2"},
 			},
 		},
 	}
@@ -345,8 +345,8 @@ func TestRenamedConsulApps_OnCustomNameAddedToNonConsulApp(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app1"},
-				{Type: "StartApplication", AppId: "app2"},
+				{Type: "RestartApplication", AppID: "app1"},
+				{Type: "StartApplication", AppID: "app2"},
 			},
 		},
 	}
@@ -378,8 +378,8 @@ func TestRenamedConsulApps_OnConsulLabelRemoved(t *testing.T) {
 		},
 		CurrentStep: &CurrentStep{
 			Actions: []*Action{
-				{Type: "RestartApplication", AppId: "app1"},
-				{Type: "StartApplication", AppId: "app2"},
+				{Type: "RestartApplication", AppID: "app1"},
+				{Type: "StartApplication", AppID: "app2"},
 			},
 		},
 	}

--- a/events/task_health_change.go
+++ b/events/task_health_change.go
@@ -8,9 +8,9 @@ import (
 
 type TaskHealthChange struct {
 	Timestamp  string      `json:"timestamp"`
-	ID         apps.TaskId `json:"id"`
+	ID         apps.TaskID `json:"id"`
 	TaskStatus string      `json:"taskStatus"`
-	AppID      apps.AppId  `json:"appId"`
+	AppID      apps.AppID  `json:"appId"`
 	Version    string      `json:"version"`
 	Alive      bool        `json:"alive"`
 }

--- a/events/unhealthy_task_kill.go
+++ b/events/unhealthy_task_kill.go
@@ -8,8 +8,8 @@ import (
 
 type UnhealthyTaskKilled struct {
 	Timestamp string      `json:"timestamp"`
-	ID        apps.TaskId `json:"taskId"`
-	AppID     apps.AppId  `json:"appId"`
+	ID        apps.TaskID `json:"taskId"`
+	AppID     apps.AppID  `json:"appId"`
 	Version   string      `json:"version"`
 }
 

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -56,10 +56,10 @@ func New(config Config) (*Marathon, error) {
 	}, nil
 }
 
-func (m Marathon) App(appId apps.AppID) (*apps.App, error) {
-	log.WithField("Location", m.Location).Debug("Asking Marathon for " + appId)
+func (m Marathon) App(appID apps.AppID) (*apps.App, error) {
+	log.WithField("Location", m.Location).Debug("Asking Marathon for " + appID)
 
-	body, err := m.get(m.urlWithQuery(fmt.Sprintf("/v2/apps/%s", appId), params{"embed": "apps.tasks"}))
+	body, err := m.get(m.urlWithQuery(fmt.Sprintf("/v2/apps/%s", appID), params{"embed": "apps.tasks"}))
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (m Marathon) Tasks(app apps.AppID) ([]*apps.Task, error) {
 		"Id":       app,
 	}).Debug("asking Marathon for tasks")
 
-	trimmedAppId := strings.Trim(app.String(), "/")
-	body, err := m.get(m.url(fmt.Sprintf("/v2/apps/%s/tasks", trimmedAppId)))
+	trimmedAppID := strings.Trim(app.String(), "/")
+	body, err := m.get(m.url(fmt.Sprintf("/v2/apps/%s/tasks", trimmedAppID)))
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (m Marathon) get(url string) ([]byte, error) {
 }
 
 func (m Marathon) logHTTPError(resp *http.Response, err error) {
-	var statusCode string = "???"
+	statusCode := "???"
 	if resp != nil {
 		statusCode = fmt.Sprintf("%d", resp.StatusCode)
 	}

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -16,8 +16,8 @@ import (
 
 type Marathoner interface {
 	ConsulApps() ([]*apps.App, error)
-	App(apps.AppId) (*apps.App, error)
-	Tasks(apps.AppId) ([]*apps.Task, error)
+	App(apps.AppID) (*apps.App, error)
+	Tasks(apps.AppID) ([]*apps.Task, error)
 	Leader() (string, error)
 }
 
@@ -56,7 +56,7 @@ func New(config Config) (*Marathon, error) {
 	}, nil
 }
 
-func (m Marathon) App(appId apps.AppId) (*apps.App, error) {
+func (m Marathon) App(appId apps.AppID) (*apps.App, error) {
 	log.WithField("Location", m.Location).Debug("Asking Marathon for " + appId)
 
 	body, err := m.get(m.urlWithQuery(fmt.Sprintf("/v2/apps/%s", appId), params{"embed": "apps.tasks"}))
@@ -69,7 +69,7 @@ func (m Marathon) App(appId apps.AppId) (*apps.App, error) {
 
 func (m Marathon) ConsulApps() ([]*apps.App, error) {
 	log.WithField("Location", m.Location).Debug("Asking Marathon for apps")
-	body, err := m.get(m.urlWithQuery("/v2/apps", params{"embed": "apps.tasks", "label": apps.MARATHON_CONSUL_LABEL}))
+	body, err := m.get(m.urlWithQuery("/v2/apps", params{"embed": "apps.tasks", "label": apps.MarathonConsulLabel}))
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (m Marathon) ConsulApps() ([]*apps.App, error) {
 	return apps.ParseApps(body)
 }
 
-func (m Marathon) Tasks(app apps.AppId) ([]*apps.Task, error) {
+func (m Marathon) Tasks(app apps.AppID) ([]*apps.Task, error) {
 	log.WithFields(log.Fields{
 		"Location": m.Location,
 		"Id":       app,

--- a/marathon/marathon_stub.go
+++ b/marathon/marathon_stub.go
@@ -1,7 +1,7 @@
 package marathon
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/allegro/marathon-consul/apps"
 )
@@ -23,18 +23,16 @@ func (m *MarathonerStub) App(id apps.AppID) (*apps.App, error) {
 	m.interactions = true
 	if app, ok := m.AppStub[id]; ok {
 		return app, nil
-	} else {
-		return nil, fmt.Errorf("app not found")
 	}
+	return nil, errors.New("app not found")
 }
 
-func (m *MarathonerStub) Tasks(appId apps.AppID) ([]*apps.Task, error) {
+func (m *MarathonerStub) Tasks(appID apps.AppID) ([]*apps.Task, error) {
 	m.interactions = true
-	if app, ok := m.TasksStub[appId]; ok {
+	if app, ok := m.TasksStub[appID]; ok {
 		return app, nil
-	} else {
-		return nil, fmt.Errorf("app not found")
 	}
+	return nil, errors.New("app not found")
 }
 
 func (m *MarathonerStub) Leader() (string, error) {

--- a/marathon/marathon_stub.go
+++ b/marathon/marathon_stub.go
@@ -8,8 +8,8 @@ import (
 
 type MarathonerStub struct {
 	AppsStub     []*apps.App
-	AppStub      map[apps.AppId]*apps.App
-	TasksStub    map[apps.AppId][]*apps.Task
+	AppStub      map[apps.AppID]*apps.App
+	TasksStub    map[apps.AppID][]*apps.Task
 	leader       string
 	interactions bool
 }
@@ -19,7 +19,7 @@ func (m *MarathonerStub) ConsulApps() ([]*apps.App, error) {
 	return m.AppsStub, nil
 }
 
-func (m *MarathonerStub) App(id apps.AppId) (*apps.App, error) {
+func (m *MarathonerStub) App(id apps.AppID) (*apps.App, error) {
 	m.interactions = true
 	if app, ok := m.AppStub[id]; ok {
 		return app, nil
@@ -28,7 +28,7 @@ func (m *MarathonerStub) App(id apps.AppId) (*apps.App, error) {
 	}
 }
 
-func (m *MarathonerStub) Tasks(appId apps.AppId) ([]*apps.Task, error) {
+func (m *MarathonerStub) Tasks(appId apps.AppID) ([]*apps.Task, error) {
 	m.interactions = true
 	if app, ok := m.TasksStub[appId]; ok {
 		return app, nil
@@ -53,8 +53,8 @@ func MarathonerStubWithLeaderForApps(leader string, args ...*apps.App) *Marathon
 }
 
 func MarathonerStubForApps(args ...*apps.App) *MarathonerStub {
-	appsMap := make(map[apps.AppId]*apps.App)
-	tasksMap := make(map[apps.AppId][]*apps.Task)
+	appsMap := make(map[apps.AppID]*apps.App)
+	tasksMap := make(map[apps.AppID][]*apps.Task)
 
 	for _, app := range args {
 		appsMap[app.ID] = app

--- a/scripts/migrate_to_marathon_task_tag/main.go
+++ b/scripts/migrate_to_marathon_task_tag/main.go
@@ -112,7 +112,7 @@ func migrateServicesOnNode(services map[string]*api.AgentService, nodeClient *ap
 
 		if err := nodeClient.Agent().ServiceRegister(migrated(agentService)); err != nil {
 			log.WithError(err).WithField("ServiceID", agentService.ID).
-			Warn("Could not reregister service, skipping")
+				Warn("Could not reregister service, skipping")
 			stats.SkippedFailedServices++
 			continue
 		}

--- a/scripts/migrate_to_marathon_task_tag/main_test.go
+++ b/scripts/migrate_to_marathon_task_tag/main_test.go
@@ -15,7 +15,7 @@ import (
 func TestMigrateToMarathonTaskTag_shouldMigrateOnlyServicesWithMarathonTagAndWithoutTaskTag(t *testing.T) {
 	t.Parallel()
 	// given
-	server := consul.CreateConsulTestServer(t)
+	server := consul.CreateTestServer(t)
 	defer server.Stop()
 	server.AddService("serviceA", "passing", []string{"marathon"})
 	server.AddService("serviceB-critical", "critical", []string{"marathon"})
@@ -40,7 +40,7 @@ func TestMigrateToMarathonTaskTag_shouldMigrateOnlyServicesWithMarathonTagAndWit
 func TestMigrateToMarathonTaskTag_shouldLeaveServicePropertiesOtherThanTagsUnchanged(t *testing.T) {
 	t.Parallel()
 	// given
-	server := consul.CreateConsulTestServer(t)
+	server := consul.CreateTestServer(t)
 	defer server.Stop()
 	client, _ := clientToServer(server)
 	client.Agent().ServiceRegister(&api.AgentServiceRegistration{
@@ -81,9 +81,9 @@ func TestMigrateToMarathonTaskTag_shouldLeaveServicePropertiesOtherThanTagsUncha
 func TestMigrateToMarathonTaskTag_shouldMigrateServicesInBootstrapAgentsDCOnly(t *testing.T) {
 	t.Parallel()
 	// given
-	server := consul.CreateConsulTestServer(t)
+	server := consul.CreateTestServer(t)
 	defer server.Stop()
-	serverOnOtherDC := consul.CreateConsulTestServer(t)
+	serverOnOtherDC := consul.CreateTestServer(t)
 	defer serverOnOtherDC.Stop()
 	server.JoinWAN(serverOnOtherDC.WANAddr)
 
@@ -105,7 +105,7 @@ func TestMigrateToMarathonTaskTag_shouldMigrateServicesInBootstrapAgentsDCOnly(t
 func TestMigrateToMarathonTaskTag_shouldMigrateThroughCallingMain(t *testing.T) {
 	t.Parallel()
 	// given
-	server := consul.CreateConsulTestServer(t)
+	server := consul.CreateTestServer(t)
 	defer server.Stop()
 	server.AddService("serviceA", "passing", []string{"marathon"})
 	os.Args = []string{"./migrate", fmt.Sprintf("--bootstrap-agent-location=%s", server.HTTPAddr)}

--- a/service/service.go
+++ b/service/service.go
@@ -21,16 +21,16 @@ type Service struct {
 	RegisteringAgentAddress string
 }
 
-func (s *Service) TaskId() (apps.TaskId, error) {
+func (s *Service) TaskId() (apps.TaskID, error) {
 	for _, tag := range s.Tags {
 		if strings.HasPrefix(tag, "marathon-task:") {
-			return apps.TaskId(strings.TrimPrefix(tag, "marathon-task:")), nil
+			return apps.TaskID(strings.TrimPrefix(tag, "marathon-task:")), nil
 		}
 	}
-	return apps.TaskId(""), errors.New("marathon-task tag missing")
+	return apps.TaskID(""), errors.New("marathon-task tag missing")
 }
 
-func MarathonTaskTag(taskId apps.TaskId) string {
+func MarathonTaskTag(taskId apps.TaskID) string {
 	return fmt.Sprintf("marathon-task:%s", taskId)
 }
 
@@ -38,7 +38,7 @@ type ServiceRegistry interface {
 	GetAllServices() ([]*Service, error)
 	GetServices(name string) ([]*Service, error)
 	Register(task *apps.Task, app *apps.App) error
-	DeregisterByTask(taskId apps.TaskId) error
+	DeregisterByTask(taskId apps.TaskID) error
 	Deregister(toDeregister *Service) error
 	ServiceNames(app *apps.App) []string
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMarathonTaskTAg(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "marathon-task:my-task", MarathonTaskTag(apps.TaskId("my-task")))
+	assert.Equal(t, "marathon-task:my-task", MarathonTaskTag(apps.TaskID("my-task")))
 }
 
 func TestServiceTaskId(t *testing.T) {
@@ -19,14 +19,14 @@ func TestServiceTaskId(t *testing.T) {
 		ID:   "123",
 		Name: "abc",
 		RegisteringAgentAddress: "localhost",
-		Tags: []string{MarathonTaskTag("my-task")},
+		Tags:                    []string{MarathonTaskTag("my-task")},
 	}
 
 	// when
 	id, err := service.TaskId()
 
 	// then
-	assert.Equal(t, apps.TaskId("my-task"), id)
+	assert.Equal(t, apps.TaskID("my-task"), id)
 	assert.NoError(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestServiceTaskId_NoMarathonTaskTag(t *testing.T) {
 		ID:   "123",
 		Name: "abc",
 		RegisteringAgentAddress: "localhost",
-		Tags: []string{},
+		Tags:                    []string{},
 	}
 
 	// when

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -18,8 +18,8 @@ func TestServiceTaskId(t *testing.T) {
 	service := Service{
 		ID:   "123",
 		Name: "abc",
+		Tags: []string{MarathonTaskTag("my-task")},
 		RegisteringAgentAddress: "localhost",
-		Tags:                    []string{MarathonTaskTag("my-task")},
 	}
 
 	// when
@@ -36,8 +36,8 @@ func TestServiceTaskId_NoMarathonTaskTag(t *testing.T) {
 	service := Service{
 		ID:   "123",
 		Name: "abc",
+		Tags: []string{},
 		RegisteringAgentAddress: "localhost",
-		Tags:                    []string{},
 	}
 
 	// when

--- a/sync/config.go
+++ b/sync/config.go
@@ -4,7 +4,7 @@ import "time"
 
 type Config struct {
 	Enabled  bool
+	Force    bool
 	Interval time.Duration
 	Leader   string
-	Force    bool
 }

--- a/sync/error_marathon_stub_test.go
+++ b/sync/error_marathon_stub_test.go
@@ -13,11 +13,11 @@ func (m errorMarathon) ConsulApps() ([]*apps.App, error) {
 	return nil, fmt.Errorf("Error")
 }
 
-func (m errorMarathon) App(id apps.AppId) (*apps.App, error) {
+func (m errorMarathon) App(id apps.AppID) (*apps.App, error) {
 	return nil, fmt.Errorf("Error")
 }
 
-func (m errorMarathon) Tasks(appId apps.AppId) ([]*apps.Task, error) {
+func (m errorMarathon) Tasks(appId apps.AppID) ([]*apps.Task, error) {
 	return nil, fmt.Errorf("Error")
 }
 

--- a/sync/error_marathon_stub_test.go
+++ b/sync/error_marathon_stub_test.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/allegro/marathon-consul/apps"
 )
@@ -10,17 +10,17 @@ type errorMarathon struct {
 }
 
 func (m errorMarathon) ConsulApps() ([]*apps.App, error) {
-	return nil, fmt.Errorf("Error")
+	return nil, errors.New("Error")
 }
 
 func (m errorMarathon) App(id apps.AppID) (*apps.App, error) {
-	return nil, fmt.Errorf("Error")
+	return nil, errors.New("Error")
 }
 
-func (m errorMarathon) Tasks(appId apps.AppID) ([]*apps.Task, error) {
-	return nil, fmt.Errorf("Error")
+func (m errorMarathon) Tasks(appID apps.AppID) ([]*apps.Task, error) {
+	return nil, errors.New("Error")
 }
 
 func (m errorMarathon) Leader() (string, error) {
-	return "", fmt.Errorf("Error")
+	return "", errors.New("Error")
 }

--- a/sync/error_service_registry_stub_test.go
+++ b/sync/error_service_registry_stub_test.go
@@ -1,8 +1,8 @@
 package sync
 
-import "fmt"
-
 import (
+	"errors"
+
 	"github.com/allegro/marathon-consul/apps"
 	"github.com/allegro/marathon-consul/service"
 )
@@ -11,23 +11,23 @@ type errorServiceRegistry struct {
 }
 
 func (c errorServiceRegistry) GetServices(name string) ([]*service.Service, error) {
-	return nil, fmt.Errorf("Error occured")
+	return nil, errors.New("Error occured")
 }
 
 func (c errorServiceRegistry) GetAllServices() ([]*service.Service, error) {
-	return nil, fmt.Errorf("Error occured")
+	return nil, errors.New("Error occured")
 }
 
 func (c errorServiceRegistry) Register(task *apps.Task, app *apps.App) error {
-	return fmt.Errorf("Error occured")
+	return errors.New("Error occured")
 }
 
-func (c errorServiceRegistry) DeregisterByTask(taskId apps.TaskID) error {
-	return fmt.Errorf("Error occured")
+func (c errorServiceRegistry) DeregisterByTask(taskID apps.TaskID) error {
+	return errors.New("Error occured")
 }
 
 func (c errorServiceRegistry) Deregister(toDeregister *service.Service) error {
-	return fmt.Errorf("Error occured")
+	return errors.New("Error occured")
 }
 
 func (c errorServiceRegistry) ServiceNames(app *apps.App) []string {

--- a/sync/error_service_registry_stub_test.go
+++ b/sync/error_service_registry_stub_test.go
@@ -22,7 +22,7 @@ func (c errorServiceRegistry) Register(task *apps.Task, app *apps.App) error {
 	return fmt.Errorf("Error occured")
 }
 
-func (c errorServiceRegistry) DeregisterByTask(taskId apps.TaskId) error {
+func (c errorServiceRegistry) DeregisterByTask(taskId apps.TaskID) error {
 	return fmt.Errorf("Error occured")
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -154,7 +154,7 @@ func (s *Sync) registerAppTasksNotFoundInConsul(marathonApps []*apps.App, servic
 			if registrations := registrationsUnderTaskIds[task.ID]; registrations != expectedRegistrations {
 				if registrations != 0 {
 					log.WithField("Id", task.ID).WithField("HasRegistrations", registrations).
-					WithField("ExpectedRegistrations", expectedRegistrations).Info("Registering missing service registrations")
+						WithField("ExpectedRegistrations", expectedRegistrations).Info("Registering missing service registrations")
 				}
 				if task.IsHealthy() {
 					err := s.serviceRegistry.Register(&task, app)
@@ -171,8 +171,8 @@ func (s *Sync) registerAppTasksNotFoundInConsul(marathonApps []*apps.App, servic
 	}
 }
 
-func (s *Sync) taskIdsInConsulServices(services []*service.Service) map[apps.TaskId]int {
-	serviceCounters := make(map[apps.TaskId]int)
+func (s *Sync) taskIdsInConsulServices(services []*service.Service) map[apps.TaskID]int {
+	serviceCounters := make(map[apps.TaskID]int)
 	for _, service := range services {
 		if taskId, err := service.TaskId(); err == nil {
 			serviceCounters[taskId] += 1
@@ -181,8 +181,8 @@ func (s *Sync) taskIdsInConsulServices(services []*service.Service) map[apps.Tas
 	return serviceCounters
 }
 
-func (s *Sync) marathonTaskIdsSet(marathonApps []*apps.App) map[apps.TaskId]struct{} {
-	tasksSet := make(map[apps.TaskId]struct{})
+func (s *Sync) marathonTaskIdsSet(marathonApps []*apps.App) map[apps.TaskID]struct{} {
+	tasksSet := make(map[apps.TaskID]struct{})
 	var exists struct{}
 	for _, app := range marathonApps {
 		for _, task := range app.Tasks {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -160,7 +160,7 @@ func (c *ConsulServicesMock) RegistrationsCount(instanceId string) int {
 	return c.registrations[instanceId]
 }
 
-func (c *ConsulServicesMock) DeregisterByTask(taskId apps.TaskId) error {
+func (c *ConsulServicesMock) DeregisterByTask(taskId apps.TaskID) error {
 	return nil
 }
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -359,7 +359,7 @@ func TestSync_WithDeregisteringProblems(t *testing.T) {
 	}
 	allServices, _ := consulStub.GetAllServices()
 	for _, s := range allServices {
-		consulStub.FailDeregisterForId(s.ID)
+		consulStub.FailDeregisterForID(s.ID)
 	}
 
 	sync := newSyncWithDefaultConfig(marathon, consulStub)
@@ -401,10 +401,10 @@ func newSyncWithDefaultConfig(marathon marathon.Marathoner, serviceRegistry serv
 func TestSync_AddingAgentsFromMarathonTasks(t *testing.T) {
 	t.Parallel()
 
-	consulServer := consul.CreateConsulTestServer(t)
+	consulServer := consul.CreateTestServer(t)
 	defer consulServer.Stop()
 
-	consulInstance := consul.New(consul.ConsulConfig{
+	consulInstance := consul.New(consul.Config{
 		Port: fmt.Sprintf("%d", consulServer.Config.Ports.HTTP),
 		Tag:  "marathon",
 	})

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -156,11 +156,11 @@ func (c *ConsulServicesMock) Register(task *apps.Task, app *apps.App) error {
 	return nil
 }
 
-func (c *ConsulServicesMock) RegistrationsCount(instanceId string) int {
-	return c.registrations[instanceId]
+func (c *ConsulServicesMock) RegistrationsCount(instanceID string) int {
+	return c.registrations[instanceID]
 }
 
-func (c *ConsulServicesMock) DeregisterByTask(taskId apps.TaskID) error {
+func (c *ConsulServicesMock) DeregisterByTask(taskID apps.TaskID) error {
 	return nil
 }
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -316,7 +316,7 @@ func TestSync_WithRegisteringProblems(t *testing.T) {
 	// given
 	marathon := marathon.MarathonerStubForApps(ConsulApp("/test/app", 3))
 	consul := consul.NewConsulStub()
-	consul.FailRegisterForId("test_app.1")
+	consul.FailRegisterForID("test_app.1")
 	sync := newSyncWithDefaultConfig(marathon, consul)
 	// when
 	err := sync.SyncServices()

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/allegro/marathon-consul/service"
 )
 
+var noopSyncStartedListener = func(apps []*apps.App) {}
+
 func TestSyncJob_ShouldSyncOnLeadership(t *testing.T) {
 	t.Parallel()
 	// given
@@ -32,11 +34,9 @@ func TestSyncJob_ShouldSyncOnLeadership(t *testing.T) {
 	ticker := sync.StartSyncServicesJob()
 
 	// then
-	select {
-	case <-time.After(15 * time.Millisecond):
-		ticker.Stop()
-		assert.Equal(t, 2, services.RegistrationsCount(app.Tasks[0].ID.String()))
-	}
+	<-time.After(15 * time.Millisecond)
+	ticker.Stop()
+	assert.Equal(t, 2, services.RegistrationsCount(app.Tasks[0].ID.String()))
 }
 
 func TestSyncJob_ShouldNotSyncWhenDisabled(t *testing.T) {
@@ -56,10 +56,8 @@ func TestSyncJob_ShouldNotSyncWhenDisabled(t *testing.T) {
 
 	// then
 	assert.Nil(t, ticker)
-	select {
-	case <-time.After(15 * time.Millisecond):
-		assert.Equal(t, 0, services.RegistrationsCount(app.Tasks[0].ID.String()))
-	}
+	<-time.After(15 * time.Millisecond)
+	assert.Equal(t, 0, services.RegistrationsCount(app.Tasks[0].ID.String()))
 }
 
 func TestSyncJob_ShouldDefaultLeaderConfigurationToResolvedHostname(t *testing.T) {
@@ -78,11 +76,9 @@ func TestSyncJob_ShouldDefaultLeaderConfigurationToResolvedHostname(t *testing.T
 	ticker := sync.StartSyncServicesJob()
 
 	// then
-	select {
-	case <-time.After(15 * time.Millisecond):
-		ticker.Stop()
-		assert.Equal(t, 2, services.RegistrationsCount(app.Tasks[0].ID.String()))
-	}
+	<-time.After(15 * time.Millisecond)
+	ticker.Stop()
+	assert.Equal(t, 2, services.RegistrationsCount(app.Tasks[0].ID.String()))
 }
 
 func TestSyncServices_ShouldNotSyncOnNoForceNorLeaderSpecified(t *testing.T) {

--- a/utils/apps.go
+++ b/utils/apps.go
@@ -28,11 +28,11 @@ func app(name string, instances int, registrationsPerInstance int, consul bool, 
 	for i := 0; i < instances; i++ {
 		var ports []int
 		for j := 1; j <= registrationsPerInstance; j++ {
-			ports = append(ports, 8080 + (i * j) + j - 1)
+			ports = append(ports, 8080+(i*j)+j-1)
 		}
 		task := apps.Task{
-			AppID: apps.AppId(name),
-			ID:    apps.TaskId(fmt.Sprintf("%s.%d", strings.Replace(strings.Trim(name, "/"), "/", "_", -1), i)),
+			AppID: apps.AppID(name),
+			ID:    apps.TaskID(fmt.Sprintf("%s.%d", strings.Replace(strings.Trim(name, "/"), "/", "_", -1), i)),
 			Ports: ports,
 			Host:  "localhost",
 		}
@@ -50,11 +50,11 @@ func app(name string, instances int, registrationsPerInstance int, consul bool, 
 
 	labels := make(map[string]string)
 	if consul {
-		labels[apps.MARATHON_CONSUL_LABEL] = "true"
+		labels[apps.MarathonConsulLabel] = "true"
 	}
 
 	app := &apps.App{
-		ID:     apps.AppId(name),
+		ID:     apps.AppID(name),
 		Tasks:  appTasks,
 		Labels: labels,
 	}
@@ -62,7 +62,7 @@ func app(name string, instances int, registrationsPerInstance int, consul bool, 
 	if registrationsPerInstance > 1 {
 		for i := 0; i < registrationsPerInstance; i++ {
 			app.PortDefinitions = append(app.PortDefinitions, apps.PortDefinition{
-				Port: 0,
+				Port:   0,
 				Labels: map[string]string{"consul": ""},
 			})
 		}

--- a/web/event_handler.go
+++ b/web/event_handler.go
@@ -245,7 +245,7 @@ func (fh *eventHandler) deregisterAllAppServices(app *apps.App) []error {
 			errors = append(errors, err)
 			continue
 		}
-		if taskId.AppId() == app.ID {
+		if taskId.AppID() == app.ID {
 			err = fh.deregister(taskId)
 			if err != nil {
 				errors = append(errors, err)
@@ -255,7 +255,7 @@ func (fh *eventHandler) deregisterAllAppServices(app *apps.App) []error {
 	return errors
 }
 
-func (fh *eventHandler) deregister(taskId apps.TaskId) error {
+func (fh *eventHandler) deregister(taskId apps.TaskID) error {
 	err := fh.serviceRegistry.DeregisterByTask(taskId)
 	if err != nil {
 		log.WithField("Id", taskId).WithError(err).Error("There was a problem deregistering task")
@@ -263,7 +263,7 @@ func (fh *eventHandler) deregister(taskId apps.TaskId) error {
 	return err
 }
 
-func findTaskById(id apps.TaskId, tasks_ []apps.Task) (apps.Task, error) {
+func findTaskById(id apps.TaskID, tasks_ []apps.Task) (apps.Task, error) {
 	for _, task := range tasks_ {
 		if task.ID == id {
 			return task, nil

--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -141,7 +141,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationAction(t *testing.T) 
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	app.Tasks = []apps.Task{} // tasks are not available in this event
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app))
@@ -154,7 +154,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationAction(t *testing.T) 
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Empty(t, service.RegisteredTaskIds())
+	assert.Empty(t, service.RegisteredTaskIDs())
 	assert.False(t, marathon.Interactions())
 }
 
@@ -168,7 +168,7 @@ func TestWebHandler_handleDeploymentInfoWithStopApplicationForOneApp(t *testing.
 	blue.Labels[apps.MarathonConsulLabel] = "app"
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(green, blue)
-	assert.Len(t, service.RegisteredTaskIds(), 5)
+	assert.Len(t, service.RegisteredTaskIDs(), 5)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(green))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -180,7 +180,7 @@ func TestWebHandler_handleDeploymentInfoWithStopApplicationForOneApp(t *testing.
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 2)
+	assert.Len(t, service.RegisteredTaskIDs(), 2)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -192,7 +192,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForMultipleApps
 	app2 := ConsulApp("/test/otherapp", 2)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app1, app2)
-	assert.Len(t, service.RegisteredTaskIds(), 5)
+	assert.Len(t, service.RegisteredTaskIDs(), 5)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app1, app2))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -204,7 +204,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForMultipleApps
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 0)
+	assert.Len(t, service.RegisteredTaskIDs(), 0)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -216,8 +216,8 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForMultipleApps
 	app2 := ConsulApp("/test/otherapp", 2)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app1, app2)
-	service.FailDeregisterByTaskForId("test_app.1")
-	assert.Len(t, service.RegisteredTaskIds(), 5)
+	service.FailDeregisterByTaskForID("test_app.1")
+	assert.Len(t, service.RegisteredTaskIDs(), 5)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app1, app2))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -229,7 +229,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForMultipleApps
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 1)
+	assert.Len(t, service.RegisteredTaskIDs(), 1)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -240,7 +240,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionWithNoServicesR
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := consul.NewConsulStub()
-	assert.Len(t, service.RegisteredTaskIds(), 0)
+	assert.Len(t, service.RegisteredTaskIDs(), 0)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -252,7 +252,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionWithNoServicesR
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 0)
+	assert.Len(t, service.RegisteredTaskIDs(), 0)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -263,7 +263,7 @@ func TestWebHandler_HandleDeploymentInfoWithInvalidBody(t *testing.T) {
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(`{"eventType":"deployment_info", "Plan": 123}`)))
 
@@ -274,7 +274,7 @@ func TestWebHandler_HandleDeploymentInfoWithInvalidBody(t *testing.T) {
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -285,7 +285,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForNonConsulApp
 	app := NonConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -297,7 +297,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForNonConsulApp
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -309,7 +309,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForCustomServic
 	app.Labels["consul"] = "someCustomServiceName"
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -321,7 +321,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionForCustomServic
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 0)
+	assert.Len(t, service.RegisteredTaskIDs(), 0)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -332,7 +332,7 @@ func TestWebHandler_NotHandleDeploymentInfoWithScaleApplicationAction(t *testing
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	deploymentInfo := deploymentInfoWithStopApplicationActionForApps(app)
 	deploymentInfo.CurrentStep.Actions[0].Type = "ScaleApplication"
@@ -346,7 +346,7 @@ func TestWebHandler_NotHandleDeploymentInfoWithScaleApplicationAction(t *testing
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -357,8 +357,8 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionAndProblemsDere
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	service.FailDeregisterByTaskForId("test_app.1")
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	service.FailDeregisterByTaskForID("test_app.1")
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentInfoWithStopApplicationActionForApps(app))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -370,7 +370,7 @@ func TestWebHandler_HandleDeploymentInfoWithStopApplicationActionAndProblemsDere
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 1)
+	assert.Len(t, service.RegisteredTaskIDs(), 1)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -401,7 +401,7 @@ func TestWebHandler_HandleDeploymentStepSuccessWithRestartAndRenameApplicationAc
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentStepSuccessWithRestartAndRenameApplicationActionForApps(app))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -413,7 +413,7 @@ func TestWebHandler_HandleDeploymentStepSuccessWithRestartAndRenameApplicationAc
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 0)
+	assert.Len(t, service.RegisteredTaskIDs(), 0)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -424,7 +424,7 @@ func TestWebHandler_HandleDeploymentStepSuccessWithInvalidBody(t *testing.T) {
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(`{"eventType":"deployment_step_success", "Plan": 123}`)))
 
@@ -435,7 +435,7 @@ func TestWebHandler_HandleDeploymentStepSuccessWithInvalidBody(t *testing.T) {
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 3)
+	assert.Len(t, service.RegisteredTaskIDs(), 3)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -447,8 +447,8 @@ func TestWebHandler_HandleDeploymentStepSuccessWithRestartApplicationActionForMu
 	app2 := ConsulApp("/test/otherapp", 2)
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(app1, app2)
-	service.FailDeregisterByTaskForId("test_app.1")
-	assert.Len(t, service.RegisteredTaskIds(), 5)
+	service.FailDeregisterByTaskForID("test_app.1")
+	assert.Len(t, service.RegisteredTaskIDs(), 5)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body, _ := json.Marshal(deploymentStepSuccessWithRestartAndRenameApplicationActionForApps(app1, app2))
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
@@ -460,7 +460,7 @@ func TestWebHandler_HandleDeploymentStepSuccessWithRestartApplicationActionForMu
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Len(t, service.RegisteredTaskIds(), 1)
+	assert.Len(t, service.RegisteredTaskIDs(), 1)
 	assert.False(t, marathon.Interactions())
 }
 
@@ -555,7 +555,7 @@ func TestWebHandler_NotHandleStatusEventAboutStartingTask(t *testing.T) {
 		// then
 		assert.Equal(t, 202, recorder.Code)
 		assert.Equal(t, "OK\n", recorder.Body.String())
-		assert.Empty(t, services.RegisteredTaskIds())
+		assert.Empty(t, services.RegisteredTaskIDs())
 	}
 }
 
@@ -592,7 +592,7 @@ func TestWebHandler_HandleStatusEventAboutDeadTask(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		handler.Handle(recorder, req)
 		stopChan <- stopEvent{}
-		taskIds := service.RegisteredTaskIds()
+		taskIds := service.RegisteredTaskIDs()
 
 		// then
 		assert.Equal(t, 202, recorder.Code)
@@ -631,7 +631,7 @@ func TestWebHandler_HandleEventAboutUnhealthyKilledTask(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler.Handle(recorder, req)
 	stopChan <- stopEvent{}
-	taskIds := service.RegisteredTaskIds()
+	taskIds := service.RegisteredTaskIDs()
 
 	// then
 	assert.Equal(t, 202, recorder.Code)
@@ -676,7 +676,7 @@ func TestWebHandler_HandleStatusEventAboutDeadTaskErrOnDeregistration(t *testing
 
 	// given
 	service := consul.NewConsulStub()
-	service.FailDeregisterByTaskForId("task.1")
+	service.FailDeregisterByTaskForID("task.1")
 	queue := make(chan event)
 	stopChan := newEventHandler(0, service, nil, queue).Start()
 	handler := newWebHandler(queue)
@@ -703,7 +703,7 @@ func TestWebHandler_HandleStatusEventAboutDeadTaskErrOnDeregistration(t *testing
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Empty(t, service.RegisteredTaskIds())
+	assert.Empty(t, service.RegisteredTaskIDs())
 }
 
 func TestWebHandler_NotHandleStatusEventAboutNonConsulAppsDeadTask(t *testing.T) {
@@ -781,7 +781,7 @@ func TestWebHandler_HandleHealthStatusEvent(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handle(recorder, req)
 	stop()
-	taskIds := service.RegisteredTaskIds()
+	taskIds := service.RegisteredTaskIDs()
 
 	// then
 	assertAccepted(t, recorder)
@@ -809,7 +809,7 @@ func TestWebHandler_HandleHealthStatusEventWithErrorsOnRegistration(t *testing.T
 
 	// then
 	assertAccepted(t, recorder)
-	assert.Empty(t, service.RegisteredTaskIds())
+	assert.Empty(t, service.RegisteredTaskIDs())
 	assert.True(t, marathon.Interactions())
 }
 
@@ -962,7 +962,7 @@ func TestWebHandler_HandleHealthStatusEventWhenTaskIsNotInMarathon(t *testing.T)
 	assert.True(t, marathon.Interactions())
 }
 
-func newConsulStubWithApplicationsTasksRegistered(applications ...*apps.App) *consul.ConsulStub {
+func newConsulStubWithApplicationsTasksRegistered(applications ...*apps.App) *consul.Stub {
 	service := consul.NewConsulStub()
 	for _, app := range applications {
 		for _, task := range app.Tasks {

--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -975,13 +976,13 @@ func newConsulStubWithApplicationsTasksRegistered(applications ...*apps.App) *co
 type BadReader struct{}
 
 func (r BadReader) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("Some error")
+	return 0, errors.New("Some error")
 }
 
-func healthStatusChangeEventForTask(taskId string) string {
+func healthStatusChangeEventForTask(taskID string) string {
 	return `{
 	  "appId":"/test/app",
-	  "taskId":"` + taskId + `",
+	  "taskId":"` + taskID + `",
 	  "version":"2015-12-07T09:02:48.981Z",
 	  "alive":true,
 	  "eventType":"health_status_changed_event",

--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -163,9 +163,9 @@ func TestWebHandler_handleDeploymentInfoWithStopApplicationForOneApp(t *testing.
 
 	// given
 	green := ConsulApp("/test/app.green", 3)
-	green.Labels[apps.MARATHON_CONSUL_LABEL] = "app"
+	green.Labels[apps.MarathonConsulLabel] = "app"
 	blue := ConsulApp("/test/app.blue", 2)
-	blue.Labels[apps.MARATHON_CONSUL_LABEL] = "app"
+	blue.Labels[apps.MarathonConsulLabel] = "app"
 	marathon := marathon.MarathonerStubForApps()
 	service := newConsulStubWithApplicationsTasksRegistered(green, blue)
 	assert.Len(t, service.RegisteredTaskIds(), 5)

--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -389,7 +389,7 @@ func deploymentInfoWithStopApplicationActionForApps(applications ...*apps.App) *
 	}
 	for _, app := range applications {
 		deploymentInfo.Plan.Original.Apps = append(deploymentInfo.Plan.Original.Apps, app)
-		deploymentInfo.CurrentStep.Actions = append(deploymentInfo.CurrentStep.Actions, &events.Action{AppId: app.ID, Type: "StopApplication"})
+		deploymentInfo.CurrentStep.Actions = append(deploymentInfo.CurrentStep.Actions, &events.Action{AppID: app.ID, Type: "StopApplication"})
 	}
 	return deploymentInfo
 }
@@ -486,7 +486,7 @@ func deploymentStepSuccessWithRestartAndRenameApplicationActionForApps(applicati
 			targetApp.Labels["consul"] = fmt.Sprintf("New%s", name)
 		}
 		deploymentInfo.Plan.Target.Apps = append(deploymentInfo.Plan.Target.Apps, targetApp)
-		deploymentInfo.CurrentStep.Actions = append(deploymentInfo.CurrentStep.Actions, &events.Action{AppId: app.ID, Type: "RestartApplication"})
+		deploymentInfo.CurrentStep.Actions = append(deploymentInfo.CurrentStep.Actions, &events.Action{AppID: app.ID, Type: "RestartApplication"})
 	}
 	return deploymentInfo
 }
@@ -797,7 +797,7 @@ func TestWebHandler_HandleHealthStatusEventWithErrorsOnRegistration(t *testing.T
 	app := ConsulApp("/test/app", 3)
 	marathon := marathon.MarathonerStubForApps(app)
 	service := consul.NewConsulStub()
-	service.FailRegisterForId(app.Tasks[1].ID)
+	service.FailRegisterForID(app.Tasks[1].ID)
 	handle, stop := NewHandler(Config{WorkersCount: 1}, marathon, service)
 	body := healthStatusChangeEventForTask("test_app.1")
 	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))

--- a/web/web_handler.go
+++ b/web/web_handler.go
@@ -12,15 +12,15 @@ import (
 	"github.com/allegro/marathon-consul/metrics"
 )
 
-type WebHandler struct {
+type EventHandler struct {
 	eventQueue chan event
 }
 
-func newWebHandler(eventQueue chan event) *WebHandler {
-	return &WebHandler{eventQueue: eventQueue}
+func newWebHandler(eventQueue chan event) *EventHandler {
+	return &EventHandler{eventQueue: eventQueue}
 }
 
-func (h *WebHandler) Handle(w http.ResponseWriter, r *http.Request) {
+func (h *EventHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	metrics.Time("events.response", func() {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {


### PR DESCRIPTION
Added `gometalinter` to as a Travis build step. Fixed couple of issues (mostly naming). We can't introduce `golint` until we add comment to public function/struct/type/variable/constant.