### PR TITLE
Blacklisted Healthcheck types

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ config-file                 |                 | Path to a JSON file to read conf
 consul-auth                 | `false`         | Use Consul with authentication
 consul-auth-password        |                 | The basic authentication password
 consul-auth-username        |                 | The basic authentication username
+consul-ignored-healthchecks |                 | A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp
 consul-name-separator       | `.`             | Separator used to create default service name for Consul
 consul-get-services-retry   | `3`             | Number of retries on failure when performing requests to Consul. Each retry uses different cached agent
 consul-max-agent-failures   | `3`             | Max number of consecutive request failures for agent before removal from cache

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ func (config *Config) parseFlags() {
 	flag.Uint32Var(&config.Consul.AgentFailuresTolerance, "consul-max-agent-failures", 3, "Max number of consecutive request failures for agent before removal from cache")
 	flag.Uint32Var(&config.Consul.RequestRetries, "consul-get-services-retry", 3, "Number of retries on failure when performing requests to Consul. Each retry uses different cached agent")
 	flag.StringVar(&config.Consul.ConsulNameSeparator, "consul-name-separator", ".", "Separator used to create default service name for Consul")
+	flag.StringVar(&config.Consul.IgnoredHealthChecks, "consul-ignored-healthchecks", "", "A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp")
 
 	// Web
 	flag.StringVar(&config.Web.Listen, "listen", ":4000", "Accept connections at this address")

--- a/consul/config.go
+++ b/consul/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	RequestRetries         uint32
 	AgentFailuresTolerance uint32
 	ConsulNameSeparator    string
+	IgnoredHealthChecks    string
 }
 
 type Auth struct {

--- a/debian/config.json
+++ b/debian/config.json
@@ -15,7 +15,8 @@
     "Tag": "marathon",
     "Timeout": 3000000000,
     "AgentFailuresTolerance": 3,
-    "RequestRetries": 5
+    "RequestRetries": 5,
+    "IgnoredHealthChecks": ""
   },
   "Web": {
     "Listen": ":4000",


### PR DESCRIPTION
Introducing `consul-ignored-healthchecks` configuration property which allows one to ignore specified types of Marathon health checks during service registration in Consul.

Fixes #118 