### PR TITLE
Skip tasks with excess registrations when syncing

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -164,7 +164,7 @@ func (s *Sync) registerAppTasksNotFoundInConsul(marathonApps []*apps.App, servic
 				}
 			} else if registrations > expectedRegistrations {
 				log.WithField("Id", task.ID).WithField("HasRegistrations", registrations).
-				WithField("ExpectedRegistrations", expectedRegistrations).Warn("Skipping task with excess registrations")
+					WithField("ExpectedRegistrations", expectedRegistrations).Warn("Skipping task with excess registrations")
 			} else {
 				log.WithField("Id", task.ID).Debug("Task already registered in Consul")
 			}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -148,7 +148,8 @@ func (s *Sync) registerAppTasksNotFoundInConsul(marathonApps []*apps.App, servic
 		}
 		expectedRegistrations := app.RegistrationIntentsNumber()
 		for _, task := range app.Tasks {
-			if registrations := registrationsUnderTaskIds[task.ID]; registrations != expectedRegistrations {
+			registrations := registrationsUnderTaskIds[task.ID]
+			if registrations < expectedRegistrations {
 				if registrations != 0 {
 					log.WithField("Id", task.ID).WithField("HasRegistrations", registrations).
 						WithField("ExpectedRegistrations", expectedRegistrations).Info("Registering missing service registrations")
@@ -161,6 +162,9 @@ func (s *Sync) registerAppTasksNotFoundInConsul(marathonApps []*apps.App, servic
 				} else {
 					log.WithField("Id", task.ID).Debug("Task is not healthy. Not Registering")
 				}
+			} else if registrations > expectedRegistrations {
+				log.WithField("Id", task.ID).WithField("HasRegistrations", registrations).
+				WithField("ExpectedRegistrations", expectedRegistrations).Warn("Skipping task with excess registrations")
 			} else {
 				log.WithField("Id", task.ID).Debug("Task already registered in Consul")
 			}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -349,6 +349,36 @@ func TestSync_ShouldRegisterMissingRegistrationInMultiregistrationScenario(t *te
 	assert.Len(t, services, 2)
 }
 
+/*
+This may happen if an application configuration is changed and then the deployment this triggered is rolled back.
+After rollback, the new configuration still stays with the application and there's no way to access the original configuration
+that was used to start the currently running tasks. In such case, it's possible that a given task has more registrations
+than it's now expected from the new application configuration. In order to be safe we don't want to deregister anything,
+let someone make the deployment explicitly.
+ */
+func TestSync_SkipServiceHavingMoreRegistrationsThanExpectedInMultiregistrationScenario(t *testing.T) {
+	t.Parallel()
+	// given
+	app := ConsulAppMultipleRegistrations("/test/app", 1, 2)
+	marathon := marathon.MarathonerStubForApps(app)
+	consul := consul.NewConsulStub()
+
+	consul.Register(&app.Tasks[0], app)
+	services, _ := consul.GetAllServices()
+	assert.Len(t, services, 2)
+
+	sync := newSyncWithDefaultConfig(marathon, consul)
+
+	// when
+	app.PortDefinitions[1].Labels = map[string]string{}  // make it a single-registration app
+	err := sync.SyncServices()
+
+	// then
+	services, _ = consul.GetAllServices()
+	assert.NoError(t, err)
+	assert.Len(t, services, 2)
+}
+
 func TestSync_WithDeregisteringProblems(t *testing.T) {
 	t.Parallel()
 	// given

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -350,7 +350,7 @@ func TestSync_ShouldRegisterMissingRegistrationInMultiregistrationScenario(t *te
 }
 
 /*
-This may happen if an application configuration is changed and then the deployment this triggered is rolled back.
+This may happen if an application configuration is changed and then the deployment this triggered is rolled back (deployment stopped).
 After rollback, the new configuration still stays with the application and there's no way to access the original configuration
 that was used to start the currently running tasks. In such case, it's possible that a given task has more registrations
 than it's now expected from the new application configuration. In order to be safe we don't want to deregister anything,

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -350,8 +350,8 @@ func TestSync_ShouldRegisterMissingRegistrationInMultiregistrationScenario(t *te
 }
 
 /*
-This may happen if an application configuration is changed and then the deployment this triggered is rolled back (deployment stopped).
-After rollback, the new configuration still stays with the application and there's no way to access the original configuration
+This may happen if an application configuration is changed, but there are still tasks running the older one, e.g.
+the new deployment is still in progress or was cancelled. There's no way to access the original configuration
 that was used to start the currently running tasks. In such case, it's possible that a given task has more registrations
 than it's now expected from the new application configuration. In order to be safe we don't want to deregister anything,
 let someone make the deployment explicitly.

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -355,7 +355,7 @@ After rollback, the new configuration still stays with the application and there
 that was used to start the currently running tasks. In such case, it's possible that a given task has more registrations
 than it's now expected from the new application configuration. In order to be safe we don't want to deregister anything,
 let someone make the deployment explicitly.
- */
+*/
 func TestSync_SkipServiceHavingMoreRegistrationsThanExpectedInMultiregistrationScenario(t *testing.T) {
 	t.Parallel()
 	// given
@@ -370,7 +370,7 @@ func TestSync_SkipServiceHavingMoreRegistrationsThanExpectedInMultiregistrationS
 	sync := newSyncWithDefaultConfig(marathon, consul)
 
 	// when
-	app.PortDefinitions[1].Labels = map[string]string{}  // make it a single-registration app
+	app.PortDefinitions[1].Labels = map[string]string{} // make it a single-registration app
 	err := sync.SyncServices()
 
 	// then


### PR DESCRIPTION
Explicitly handle a rare scenario during sync in which a task has more registrations than it should have according to its application configuration.

This may happen when application configuration is changed (now defining less registrations) and then the deployment this caused is rolled back – the new application configuration still stays in Marathon. Or we end up in some weird state. Since we don't know what to do in such scenario – we don't know which service to deregister – I suggest skipping such task with a log message.

We could also deregister all registrations and register the task again, but this seemed like a bad idea to me – the deployment with this new configuration was rolled back after all!