### PR TITLE
Register first, deregister second in sync process

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -76,8 +76,8 @@ func (s *Sync) syncServices() error {
 		return fmt.Errorf("Can't get Consul services: %v", err)
 	}
 
-	s.deregisterConsulServicesNotFoundInMarathon(apps, services)
 	s.registerAppTasksNotFoundInConsul(apps, services)
+	s.deregisterConsulServicesNotFoundInMarathon(apps, services)
 
 	log.Info("Syncing services finished")
 	return nil


### PR DESCRIPTION
Switching registering and deregistering places for smooth migration from 0.4.x to 1.0.0, without having to migrate using this script #106. We want to register services in the new format before removing the old entries to avoid unavailability. Shouldn't make a difference for the synchronization process. @janisz do you see any potential problem with that?