### PR TITLE
Ignoring portDefinitions.port field, always picking task ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,15 +233,11 @@ via Marathon's `portDefinitions`:
   },
   "portDefinitions": [
     {
-      "port": 0,
-      "protocol": "tcp",
       "labels": {
         "consul": "my-app-custom-name"
       }
     },
     {
-      "port": 0,
-      "protocol": "tcp",
       "labels": {
         "consul": "my-app-other-name",
         "specific-tag": "tag"
@@ -285,9 +281,6 @@ though its value won't have any effect.
 
 Tags configured in the top-level application labels will be added to all registrations. Tags configured in the port definition 
 labels will be added only to corresponding registrations.
-
-You can either provide explicit port numbers or provide 0, in which case randomly assigned ports will be used. Read more
-in [Marathon's documentation](https://mesosphere.github.io/marathon/docs/ports.html).
 
 All registrations share the same `marathon-task` tag.
 

--- a/apps/app.go
+++ b/apps/app.go
@@ -25,7 +25,6 @@ type HealthCheck struct {
 }
 
 type PortDefinition struct {
-	Port   int               `json:"port"`
 	Labels map[string]string `json:"labels"`
 }
 
@@ -151,7 +150,7 @@ func (app *App) RegistrationIntents(task *Task, nameSeparator string) []*Registr
 	for _, d := range definitions {
 		intents = append(intents, &RegistrationIntent{
 			Name: app.labelsToName(d.Labels, nameSeparator),
-			Port: d.toPort(task),
+			Port: task.Ports[d.Index],
 			Tags: append(commonTags, labelsToTags(d.Labels)...),
 		})
 	}
@@ -185,15 +184,7 @@ func (app *App) labelsToName(labels map[string]string, nameSeparator string) str
 
 type indexedPortDefinition struct {
 	Index  int
-	Port   int
 	Labels map[string]string
-}
-
-func (i *indexedPortDefinition) toPort(task *Task) int {
-	if i.Port == 0 {
-		return task.Ports[i.Index]
-	}
-	return i.Port
 }
 
 func (app *App) findConsulPortDefinitions() []indexedPortDefinition {
@@ -202,7 +193,6 @@ func (app *App) findConsulPortDefinitions() []indexedPortDefinition {
 		if _, ok := d.Labels[MarathonConsulLabel]; ok {
 			definitions = append(definitions, indexedPortDefinition{
 				Index:  i,
-				Port:   d.Port,
 				Labels: d.Labels,
 			})
 		}

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -298,31 +298,6 @@ func TestRegistrationIntent_PickDifferentPortViaPortDefinitions(t *testing.T) {
 	assert.Equal(t, 5678, intent.Port)
 }
 
-func TestRegistrationIntent_PickExplicitPortViaPortDefinitions(t *testing.T) {
-	t.Parallel()
-
-	// given
-	app := &App{
-		ID:     "app-name",
-		Labels: map[string]string{"consul": "true", "private": "tag"},
-		PortDefinitions: []PortDefinition{
-			{
-				Port:   1337,
-				Labels: map[string]string{"consul": "true"},
-			},
-		},
-	}
-	task := &Task{
-		Ports: []int{},
-	}
-
-	// when
-	intent := app.RegistrationIntents(task, "-")[0]
-
-	// then
-	assert.Equal(t, 1337, intent.Port)
-}
-
 func TestRegistrationIntent_MultipleIntentsViaPortDefinitionIfMultipleContainConsulLabel(t *testing.T) {
 	t.Parallel()
 

--- a/utils/apps.go
+++ b/utils/apps.go
@@ -62,7 +62,6 @@ func app(name string, instances int, registrationsPerInstance int, consul bool, 
 	if registrationsPerInstance > 1 {
 		for i := 0; i < registrationsPerInstance; i++ {
 			app.PortDefinitions = append(app.PortDefinitions, apps.PortDefinition{
-				Port:   0,
 				Labels: map[string]string{"consul": ""},
 			})
 		}


### PR DESCRIPTION
Turns out portDefinitions.port field always gets populated with some port, even if you configure it as 0 (in which case it's random). We should always read ports from task configuration.