### PR TITLE
Fix tests on tip (golang 1.8)

### DIFF
--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/allegro/marathon-consul/apps"
@@ -111,7 +113,12 @@ func TestWebHandler_NotHandleInvalidEventType(t *testing.T) {
 
 	// then
 	assert.Equal(t, 400, recorder.Code)
-	assert.Equal(t, "json: cannot unmarshal array into Go value of type string\n", recorder.Body.String())
+
+	if runtime.Version() < "go1.8" && !strings.HasPrefix(runtime.Version(), "devel") {
+		assert.Equal(t, "json: cannot unmarshal array into Go value of type string\n", recorder.Body.String())
+	} else {
+		assert.Equal(t, "json: cannot unmarshal array into Go struct field BaseEvent.eventType of type string\n", recorder.Body.String())
+	}
 }
 
 func TestWebHandler_HandleAppInvalidBody(t *testing.T) {

--- a/web/event_handler_test.go
+++ b/web/event_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -114,11 +113,8 @@ func TestWebHandler_NotHandleInvalidEventType(t *testing.T) {
 	// then
 	assert.Equal(t, 400, recorder.Code)
 
-	if runtime.Version() < "go1.8" && !strings.HasPrefix(runtime.Version(), "devel") {
-		assert.Equal(t, "json: cannot unmarshal array into Go value of type string\n", recorder.Body.String())
-	} else {
-		assert.Equal(t, "json: cannot unmarshal array into Go struct field BaseEvent.eventType of type string\n", recorder.Body.String())
-	}
+	assert.True(t, strings.HasPrefix(recorder.Body.String(), "json: cannot unmarshal array"))
+
 }
 
 func TestWebHandler_HandleAppInvalidBody(t *testing.T) {


### PR DESCRIPTION
In Go 1.8 json Marshaler/Unmarshaler gives more detailed errors and one of the tests depends on the exact error message.

I fixed the failing test - I'm not really sure if approach is right so I will leave it here to discuss it further