### PR TITLE
Enable deregister on TASK_KILLING

### DIFF
--- a/web/event_handler.go
+++ b/web/event_handler.go
@@ -147,7 +147,7 @@ func (fh *eventHandler) handleStatusEvent(body []byte) error {
 	}).Info("Got StatusEvent")
 
 	switch task.TaskStatus {
-	case "TASK_FINISHED", "TASK_FAILED", "TASK_KILLED", "TASK_LOST":
+	case "TASK_FINISHED", "TASK_FAILED", "TASK_KILLING", "TASK_KILLED", "TASK_LOST":
 		return fh.deregister(task.ID)
 	default:
 		log.WithFields(log.Fields{


### PR DESCRIPTION
Marathon with Mesos 0.28 has a TASK_KILLING event that will be emitted when the
task is about to get killed. This should be the earliest indicator that the
instance should be removed from consul.