### PR TITLE
Nonblocking events

### DIFF
--- a/consul/consul_stub.go
+++ b/consul/consul_stub.go
@@ -157,8 +157,8 @@ func (c *Stub) servicesMatchingTask(taskID apps.TaskID) []*consulapi.AgentServic
 	return matching
 }
 
-func (c *Stub) RegisteredTaskIDs() []apps.TaskID {
-	services, _ := c.GetAllServices()
+func (c *Stub) RegisteredTaskIDs(serviceName string) []apps.TaskID {
+	services, _ := c.GetServices(serviceName)
 	taskIds := []apps.TaskID{}
 	for _, s := range services {
 		taskID, _ := s.TaskId()

--- a/consul/consul_stub_test.go
+++ b/consul/consul_stub_test.go
@@ -39,7 +39,7 @@ func TestConsulStub(t *testing.T) {
 	// when
 	err = consul.DeregisterByTask(app.Tasks[1].ID)
 	services, _ = consul.GetAllServices()
-	taskIds := consul.RegisteredTaskIDs()
+	taskIds := consul.RegisteredTaskIDs("test")
 
 	// then
 	assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestConsulStub(t *testing.T) {
 
 	// then
 	assert.NoError(t, err)
-	assert.Len(t, consul.RegisteredTaskIDs(), 1)
+	assert.Len(t, consul.RegisteredTaskIDs("test"), 1)
 
 	// when
 	app = utils.ConsulApp("other", 2)

--- a/install_consul.sh
+++ b/install_consul.sh
@@ -20,7 +20,7 @@ hash consul 2>/dev/null || {
         os="windows"
         arch="386"
     fi
-    version="0.7.0"
+    version="0.7.2"
     archive="consul_${version}_${os}_${arch}.zip"
 
     mkdir -p bin

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -2,9 +2,10 @@ package time
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	gotime "time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimestampParsing(t *testing.T) {

--- a/web/web_handler_test.go
+++ b/web/web_handler_test.go
@@ -1,0 +1,150 @@
+package web
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const maxEventSize = 4096
+
+func TestWebHandler_Send202AcceptedWhenEventsPassesValidation(t *testing.T) {
+	t.Parallel()
+
+	// given
+	body := []byte(`{
+		  "eventType":"status_update_event",
+		  "timestamp":"2015-12-07T09:33:40.898Z"
+		}`)
+
+	queue := make(chan event, 1)
+	handler := newWebHandler(queue, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer(body))
+	recorder := httptest.NewRecorder()
+
+	// when
+	handler.Handle(recorder, req)
+
+	// then
+	assertAccepted(t, recorder)
+}
+
+func TestWebHandler_HandleReaderError(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", BadReader{})
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assert.Equal(t, 200, recorder.Code)
+	assert.Equal(t, "Some error\n", recorder.Body.String())
+}
+
+func TestWebHandler_DropBigBody(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer(make([]byte, 4097)))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assert.Equal(t, 200, recorder.Code)
+	assert.Equal(t, "http: request body too large\n", recorder.Body.String())
+}
+
+func TestWebHandler_DropEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte{}))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assertDropped(t, recorder)
+}
+
+func TestWebHandler_DropAppInvalidBody(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	body := `{"type":  "app_terminated_event", "appID": 123}`
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(body)))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assertDropped(t, recorder)
+}
+
+func TestWebHandler_DropMalformedEventType(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(`{eventType:"test_event"}`)))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assertDropped(t, recorder)
+}
+
+func TestWebHandler_DropInvalidEventType(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(`{"eventType":[1,2]}`)))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assertDropped(t, recorder)
+}
+
+func TestWebHandler_DropUnknownEventType(t *testing.T) {
+	t.Parallel()
+
+	// given
+	handler := newWebHandler(nil, maxEventSize)
+	req, _ := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(`{"eventType":"test_event"}`)))
+
+	// when
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+
+	// then
+	assertDropped(t, recorder)
+}
+
+func assertAccepted(t *testing.T, recorder *httptest.ResponseRecorder) {
+	assert.Equal(t, 202, recorder.Code)
+	assert.Equal(t, "OK\n", recorder.Body.String())
+}
+
+func assertDropped(t *testing.T, recorder *httptest.ResponseRecorder) {
+	assert.Equal(t, 200, recorder.Code)
+}


### PR DESCRIPTION
In addition to adding nonblocking handling of events i added:

* `make format` and `make check` that runs same metalinter command as travis.ci
* bumped Consul version to 0.7.2 to fix random segfaults on Mac
* fixed race condition detected by `go test -race` in `MarathonerStub`
* fixed race condition in `even_hander_test` that caused tests to fail randomly (2nd commit)

Bit more about test fixes. I moved `web_handler` test suite to `web_handler_test` and it tests only `web_handler`, the event queue is stubbed. `event_handler` tests on the other hand no longer start `web_handler`, instead events that should be processed are sent directly to the event queue. This fixes a non-trivial race condition in tests, where success of test depended on wether request will be processed by `web_handler` and sent to the queue before test reaches synchronisation point at blocking send to `event_handler` `stopChan`. 