### PR TITLE
Handle Task HealthChange without TaskID.

### DIFF
--- a/events/task_health_change.go
+++ b/events/task_health_change.go
@@ -2,21 +2,47 @@ package events
 
 import (
 	"encoding/json"
+	"errors"
+	"regexp"
 
 	"github.com/allegro/marathon-consul/apps"
 )
 
 type TaskHealthChange struct {
-	Timestamp  string      `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
+	// Prefer TaskID() instead of ID
 	ID         apps.TaskID `json:"id"`
-	TaskStatus string      `json:"taskStatus"`
+	InstanceID string      `json:"instanceId"`
 	AppID      apps.AppID  `json:"appId"`
 	Version    string      `json:"version"`
 	Alive      bool        `json:"alive"`
 }
 
+// Regular expression to extract runSpecId from instanceId
+// See: https://github.com/mesosphere/marathon/blob/v1.4.0-RC4/src/main/scala/mesosphere/marathon/core/instance/Instance.scala#L244
+var instanceIdRegex = regexp.MustCompile(`^(.+)\.(instance-|marathon-)([^\.]+)$`)
+
+func (t TaskHealthChange) TaskID() apps.TaskID {
+	if t.ID != "" {
+		return t.ID
+	}
+	return apps.TaskID(instanceIdRegex.ReplaceAllString(t.InstanceID, "$1.$3"))
+}
+
 func ParseTaskHealthChange(event []byte) (*TaskHealthChange, error) {
 	task := &TaskHealthChange{}
 	err := json.Unmarshal(event, task)
-	return task, err
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Marathon 1.4 changes this event so it does not contain TaskID.
+	// We need to validate this event if it contains required fields.
+	// See: https://phabricator.mesosphere.com/D218#10153
+	if task.ID == "" && task.InstanceID == "" {
+		return nil, errors.New("Missing task ID")
+	}
+
+	return task, nil
 }

--- a/events/task_health_change_test.go
+++ b/events/task_health_change_test.go
@@ -8,12 +8,11 @@ import (
 )
 
 var testHealthChange = &TaskHealthChange{
-	Timestamp:  "2014-03-01T23:29:30.158Z",
-	ID:         "my-app_0-1396592784349",
-	Alive:      true,
-	TaskStatus: "TASK_RUNNING",
-	AppID:      "/my-app",
-	Version:    "2014-04-04T06:26:23.051Z",
+	Timestamp: "2014-03-01T23:29:30.158Z",
+	ID:        "my-app_0-1396592784349",
+	Alive:     true,
+	AppID:     "/my-app",
+	Version:   "2014-04-04T06:26:23.051Z",
 }
 
 func TestHealthChangeParseTask(t *testing.T) {
@@ -28,7 +27,37 @@ func TestHealthChangeParseTask(t *testing.T) {
 	assert.Equal(t, testHealthChange.Timestamp, service.Timestamp)
 	assert.Equal(t, testHealthChange.ID, service.ID)
 	assert.Equal(t, testHealthChange.Alive, service.Alive)
-	assert.Equal(t, testHealthChange.TaskStatus, service.TaskStatus)
 	assert.Equal(t, testHealthChange.AppID, service.AppID)
 	assert.Equal(t, testHealthChange.Version, service.Version)
+}
+
+func TestHealthChangeParseTaskWithoutData(t *testing.T) {
+	t.Parallel()
+
+	event, err := ParseTaskHealthChange([]byte("{}"))
+	assert.Nil(t, event)
+	assert.EqualError(t, err, "Missing task ID")
+}
+
+func TestHealthChangeParseTaskWithBrokenJson(t *testing.T) {
+	t.Parallel()
+
+	event, err := ParseTaskHealthChange([]byte("not a Json"))
+	assert.Nil(t, event)
+	assert.Error(t, err)
+}
+
+func TestInstanceIDToTaskID(t *testing.T) {
+	t.Parallel()
+
+	ids := []string{
+		"python1.marathon-0bf4660a-cdc0-11e6-87df-0242ee53bf4b",
+		"python1.instance-0bf4660a-cdc0-11e6-87df-0242ee53bf4b",
+		"python1.0bf4660a-cdc0-11e6-87df-0242ee53bf4b",
+	}
+
+	for _, id := range ids {
+		instance := TaskHealthChange{InstanceID: id}
+		assert.Equal(t, "python1.0bf4660a-cdc0-11e6-87df-0242ee53bf4b", instance.TaskID().String())
+	}
 }


### PR DESCRIPTION
Marathon moved from tasks to instances to support pods.
We didn't want to add pods support right now but we need
to handle events that are not backward compatible. To do this
I introduced `TaskID()` that returns task id from instanceId if
task id was not present in event. This is shortcut just to enable
marathon-consul to be used with Marathon 1.4. We need to rethink
if/how we want to support pods and changed Marathon API.
Fixes: #148