### PR TITLE
Fixes flaky consul test.

### DIFF
--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -62,7 +62,7 @@ func FailingClient() *Consul {
 
 func consulClientAtAddress(host string, port int) *Consul {
 	config := Config{
-		Timeout:             timeutil.Interval{Duration: 10 * time.Millisecond},
+		Timeout:             timeutil.Interval{Duration: 10 * time.Second},
 		Port:                fmt.Sprintf("%d", port),
 		ConsulNameSeparator: ".",
 	}


### PR DESCRIPTION
Test are flaky due to small Consul client timeout. Fixed by increasing
client timeout.