### PR TITLE
FIX *.locahost is resolvable with nss-myhostname

### DIFF
--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -965,7 +965,7 @@ func TestMarathonTaskToConsulServiceMapping_NotResolvableTaskHost(t *testing.T) 
 	task := &apps.Task{
 		ID:    "someTask",
 		AppID: app.ID,
-		Host:  "invalid.localhost",
+		Host:  "invalid.hostname",
 		Ports: []int{8090, 8443},
 	}
 


### PR DESCRIPTION
nss-myhostname, libnss_myhostname.so.2 — Provide hostname resolution for the locally configured system hostname.
> The hostnames "localhost" and "localhost.localdomain" (as well as any hostname ending in ".localhost" or ".localhost.localdomain") are resolved to the IP addresses 127.0.0.1 and ::1.
https://www.freedesktop.org/software/systemd/man/nss-myhostname.html