### PR TITLE
Replace `[]*Tasks` with `[]Tasks`

### DIFF
--- a/apps/task.go
+++ b/apps/task.go
@@ -32,10 +32,19 @@ type HealthCheckResult struct {
 }
 
 type TasksResponse struct {
-	Tasks []*Task `json:"tasks"`
+	Tasks []Task `json:"tasks"`
 }
 
-func ParseTasks(jsonBlob []byte) ([]*Task, error) {
+func FindTaskByID(id TaskID, tasks []Task) (Task, bool) {
+	for _, task := range tasks {
+		if task.ID == id {
+			return task, true
+		}
+	}
+	return Task{}, false
+}
+
+func ParseTasks(jsonBlob []byte) ([]Task, error) {
 	tasks := &TasksResponse{}
 	err := json.Unmarshal(jsonBlob, tasks)
 

--- a/apps/task_test.go
+++ b/apps/task_test.go
@@ -37,7 +37,7 @@ func TestParseTasks(t *testing.T) {
 
 	tasksBlob, _ := ioutil.ReadFile("tasks.json")
 
-	expectedTasks := []*Task{
+	expectedTasks := []Task{
 		{
 			ID:                 "test.47de43bd-1a81-11e5-bdb6-e6cb6734eaf8",
 			AppID:              "/test",

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -17,7 +17,7 @@ import (
 type Marathoner interface {
 	ConsulApps() ([]*apps.App, error)
 	App(apps.AppID) (*apps.App, error)
-	Tasks(apps.AppID) ([]*apps.Task, error)
+	Tasks(apps.AppID) ([]apps.Task, error)
 	Leader() (string, error)
 }
 
@@ -77,7 +77,7 @@ func (m Marathon) ConsulApps() ([]*apps.App, error) {
 	return apps.ParseApps(body)
 }
 
-func (m Marathon) Tasks(app apps.AppID) ([]*apps.Task, error) {
+func (m Marathon) Tasks(app apps.AppID) ([]apps.Task, error) {
 	log.WithFields(log.Fields{
 		"Location": m.Location,
 		"Id":       app,

--- a/marathon/marathon_stub.go
+++ b/marathon/marathon_stub.go
@@ -10,7 +10,7 @@ import (
 type MarathonerStub struct {
 	AppsStub       []*apps.App
 	AppStub        map[apps.AppID]*apps.App
-	TasksStub      map[apps.AppID][]*apps.Task
+	TasksStub      map[apps.AppID][]apps.Task
 	leader         string
 	interactionsMu sync.RWMutex
 	interactions   bool
@@ -29,7 +29,7 @@ func (m *MarathonerStub) App(id apps.AppID) (*apps.App, error) {
 	return nil, errors.New("app not found")
 }
 
-func (m *MarathonerStub) Tasks(appID apps.AppID) ([]*apps.Task, error) {
+func (m *MarathonerStub) Tasks(appID apps.AppID) ([]apps.Task, error) {
 	m.noteInteraction()
 	if app, ok := m.TasksStub[appID]; ok {
 		return app, nil
@@ -62,14 +62,14 @@ func MarathonerStubWithLeaderForApps(leader string, args ...*apps.App) *Marathon
 
 func MarathonerStubForApps(args ...*apps.App) *MarathonerStub {
 	appsMap := make(map[apps.AppID]*apps.App)
-	tasksMap := make(map[apps.AppID][]*apps.Task)
+	tasksMap := make(map[apps.AppID][]apps.Task)
 
 	for _, app := range args {
 		appsMap[app.ID] = app
-		tasks := []*apps.Task{}
+		tasks := []apps.Task{}
 		for _, task := range app.Tasks {
 			t := task
-			tasks = append(tasks, &t)
+			tasks = append(tasks, t)
 		}
 		tasksMap[app.ID] = tasks
 	}

--- a/sync/error_marathon_stub_test.go
+++ b/sync/error_marathon_stub_test.go
@@ -17,7 +17,7 @@ func (m errorMarathon) App(id apps.AppID) (*apps.App, error) {
 	return nil, errors.New("Error")
 }
 
-func (m errorMarathon) Tasks(appID apps.AppID) ([]*apps.Task, error) {
+func (m errorMarathon) Tasks(appID apps.AppID) ([]apps.Task, error) {
 	return nil, errors.New("Error")
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -146,7 +146,7 @@ func (s *Sync) deregisterConsulServicesNotFoundInMarathon(marathonApps []*apps.A
 					Error("Can't get fresh info about app tasks. Will deregister this service.")
 			}
 
-			taskIsRunning := findTask(taskIDInTag, tasks)
+			_, taskIsRunning := apps.FindTaskByID(taskIDInTag, tasks)
 
 			if !taskIsRunning {
 				if err := s.serviceRegistry.Deregister(service); err != nil {
@@ -223,13 +223,4 @@ func marathonTaskIdsSet(marathonApps []*apps.App) map[apps.TaskID]struct{} {
 		}
 	}
 	return tasksSet
-}
-
-func findTask(id apps.TaskID, tasks []*apps.Task) bool {
-	for _, t := range tasks {
-		if t.ID == id {
-			return true
-		}
-	}
-	return false
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -405,8 +405,8 @@ func TestSync_WithDeregisteringFallback(t *testing.T) {
 	for _, task := range marathonApp.Tasks {
 		consulStub.Register(&task, marathonApp)
 	}
-	marathon.TasksStub = map[apps.AppID][]*apps.Task{
-		apps.AppID("/test/app"): []*apps.Task{&marathonApp.Tasks[0]},
+	marathon.TasksStub = map[apps.AppID][]apps.Task{
+		apps.AppID("/test/app"): []apps.Task{marathonApp.Tasks[0]},
 	}
 	sync := newSyncWithDefaultConfig(marathon, consulStub)
 

--- a/web/event_handler.go
+++ b/web/event_handler.go
@@ -122,9 +122,9 @@ func (fh *eventHandler) handleHealthyTask(body []byte) error {
 
 	tasks := app.Tasks
 
-	task, err := findTaskByID(taskID, tasks)
-	if err != nil {
-		log.WithField("Id", taskID).WithError(err).Error("Task not found")
+	task, found := apps.FindTaskByID(taskID, tasks)
+	if !found {
+		log.WithField("Id", taskID).Error("Task not found")
 		return err
 	}
 
@@ -171,15 +171,6 @@ func (fh *eventHandler) deregister(taskID apps.TaskID) error {
 		log.WithField("Id", taskID).WithError(err).Error("There was a problem deregistering task")
 	}
 	return err
-}
-
-func findTaskByID(id apps.TaskID, tasks []apps.Task) (apps.Task, error) {
-	for _, task := range tasks {
-		if task.ID == id {
-			return task, nil
-		}
-	}
-	return apps.Task{}, fmt.Errorf("Task %s not found", id)
 }
 
 // for every other use of Tasks, Marathon uses the "id" field for the task ID.


### PR DESCRIPTION
Task is small object (112 bytes) mostly pointers (4 strings and 2 arrays).
There is no reason for using `[]*Tasks` in Marathon response.
    
Refs: https://github.com/allegro/marathon-consul/pull/190#discussion_r103429767
