### PR TITLE
Speed up consul tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 go:
   - 1.8
+env:
+  - GOMAXPROCS=2
 before_install:
   - gem install fpm
   - go get github.com/mattn/goveralls

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -24,6 +24,8 @@ func CreateTestServer(t *testing.T) *testutil.TestServer {
 			SerfWan: ports[4],
 			Server:  ports[5],
 		}
+		c.DisableCheckpoint = true
+		c.Performance.RaftMultiplier = 1
 	})
 }
 


### PR DESCRIPTION
Setting `raft_multiplier` to 1 and disable automatic checking
for security bulletins and new version releases.

Refs:

* https://www.consul.io/docs/agent/options.html#raft_multiplier
* https://github.com/pszymczyk/embedded-consul/issues/32
* https://github.com/hashicorp/consul/issues/2705#issuecomment-283674916