### PR TITLE
support for a path in marathon location

### DIFF
--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -212,10 +212,9 @@ func (m Marathon) url(path string) string {
 
 type params map[string][]string
 
-// urlWithQuery was altered to handle a case when marathon location has a path in addition
-// to the ususal host & port. This was necessary in order to accommodate linkerd
-// (https://linkerd.io/documentation/) service discovery of marathon instance
-// eg. --marathon-location=localhost:4141/ops-staging/marathon-devteam-1
+// urlWithQuery returns absolute path to marathon endpoint
+// if location is given with path e.g. "localhost:8080/proxy/url", then
+// host and path parts are appended to respective url.URL fields
 func (m Marathon) urlWithQuery(path string, params params) string {
 	var marathon url.URL
 	if strings.Contains(m.Location, "/") {
@@ -234,6 +233,7 @@ func (m Marathon) urlWithQuery(path string, params params) string {
 			Path:   path,
 		}
 	}
+
 	query := marathon.Query()
 	for key, values := range params {
 		for _, value := range values {

--- a/marathon/marathon_test.go
+++ b/marathon/marathon_test.go
@@ -408,6 +408,30 @@ func TestEventStream_PassingStreamerCreated(t *testing.T) {
 	assert.IsType(t, &Streamer{}, streamer)
 }
 
+func TestUrlWithQuery_NoProxyMarathon(t *testing.T) {
+	t.Parallel()
+
+	// given
+	m, _ := New(Config{Location: "localhost:8080", Protocol: "HTTP"}, "")
+	// when
+	path := m.urlWithQuery("/testpath", params{})
+
+	// then
+	assert.Equal(t, "HTTP://localhost:8080/testpath", path)
+}
+
+func TestUrlWithQuery_ProxyMarathon(t *testing.T) {
+	t.Parallel()
+
+	// given
+	m, _ := New(Config{Location: "localhost:8080/proxy/url/segments", Protocol: "HTTP"}, "")
+	// when
+	path := m.urlWithQuery("/testpath", params{})
+
+	// then
+	assert.Equal(t, "HTTP://localhost:8080/proxy/url/segments/testpath", path)
+}
+
 // http://keighl.com/post/mocking-http-responses-in-golang/
 func stubServer(uri string, body string) (*httptest.Server, *http.Transport) {
 	return mockServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Hi, would you be open to adjusting the range of supported values of the marathon location parameter?

In order to join multiple marathons (e.g. per dev-team, per project) we are discovering their (semi-random) locations through linkerd (https://linkerd.io/documentation/).

This changes our --marathon-location value from the standard hostname:port into something like  --marathon-location=localhost:4141/ops-staging/marathon-devteam-1

Proposed fix checks, naively, for the existence of "path" and divides it into host  and url that is then prefixing the path param. 