### PR TITLE
Decrease request retry number to speed up tests

### DIFF
--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -142,7 +142,7 @@ func TestGetServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 	// create client
 	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
-	consul.config.RequestRetries = 100
+	consul.config.RequestRetries = 10
 
 	// given
 	server1.AddService("serviceA", "passing", []string{"public", "marathon"})
@@ -298,7 +298,7 @@ func TestGetAllServices_RemovingFailingAgentsAndRetrying(t *testing.T) {
 	// create client
 	consul := ClientAtServer(server1)
 	consul.config.Tag = "marathon"
-	consul.config.RequestRetries = 100
+	consul.config.RequestRetries = 10
 
 	// add failing clients
 	for i := uint32(2); i < consul.config.RequestRetries; i++ {


### PR DESCRIPTION
On OS X executing tests with request retry number set to 100 was taking too much time. Now it finishes in 25-60s which is acceptable.