### PR TITLE
Enable tag override to allow extrnal tools adding tags

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -126,6 +126,7 @@ func consulServiceToService(consulService *consulapi.CatalogService) *service.Se
 		Name: consulService.ServiceName,
 		Tags: consulService.ServiceTags,
 		RegisteringAgentAddress: consulService.Address,
+		EnableTagOverride: consulService.ServiceEnableTagOverride,
 	}
 }
 
@@ -186,6 +187,7 @@ func (c *Consul) register(service *consulapi.AgentServiceRegistration) error {
 		"Tags":    service.Tags,
 		"Address": service.Address,
 		"Port":    service.Port,
+		"EnableTagOverride": service.EnableTagOverride,
 	}
 	log.WithFields(fields).Info("Registering")
 
@@ -291,6 +293,7 @@ func (c *Consul) marathonTaskToConsulServices(task *apps.Task, app *apps.App) ([
 			Address: serviceAddress,
 			Tags:    tags,
 			Checks:  checks,
+			EnableTagOverride: true,
 		})
 	}
 	return registrations, nil

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ type Service struct {
 	Name                    string
 	Tags                    []string
 	RegisteringAgentAddress string
+	EnableTagOverride       bool
 }
 
 func (s *Service) TaskId() (apps.TaskID, error) {


### PR DESCRIPTION
In some cases we want to add tags to services already registered in consul. This option allow external tools to add tags to existing services and order Consul to keep tags and propagate to cluster.