### PR TITLE
Make EnableTagOverride configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ config-file                 |                 | Path to a JSON file to read conf
 consul-auth                 | `false`         | Use Consul with authentication
 consul-auth-password        |                 | The basic authentication password
 consul-auth-username        |                 | The basic authentication username
+consul-enable-tag-override  | `false`         | Disable the anti-entropy feature for all services
 consul-ignored-healthchecks |                 | A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp
 consul-name-separator       | `.`             | Separator used to create default service name for Consul
 consul-get-services-retry   | `3`             | Number of retries on failure when performing requests to Consul. Each retry uses different cached agent

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ func (config *Config) parseFlags() {
 	flag.Uint32Var(&config.Consul.RequestRetries, "consul-get-services-retry", 3, "Number of retries on failure when performing requests to Consul. Each retry uses different cached agent")
 	flag.StringVar(&config.Consul.ConsulNameSeparator, "consul-name-separator", ".", "Separator used to create default service name for Consul")
 	flag.StringVar(&config.Consul.IgnoredHealthChecks, "consul-ignored-healthchecks", "", "A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp")
+	flag.BoolVar(&config.Consul.EnableTagOverride, "consul-enable-tag-override", false, "Disable the anti-entropy feature for all services")
 
 	// Web
 	flag.StringVar(&config.Web.Listen, "listen", ":4000", "Accept connections at this address")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,7 @@ func TestConfig_ShouldBeMergedWithFileDefaultsAndFlags(t *testing.T) {
 			RequestRetries:         5,
 			AgentFailuresTolerance: 3,
 			ConsulNameSeparator:    ".",
+			EnableTagOverride:      false,
 		},
 		Web: web.Config{
 			Listen:       ":4000",

--- a/consul/config.go
+++ b/consul/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	AgentFailuresTolerance uint32
 	ConsulNameSeparator    string
 	IgnoredHealthChecks    string
+	EnableTagOverride      bool
 }
 
 type Auth struct {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -293,7 +293,7 @@ func (c *Consul) marathonTaskToConsulServices(task *apps.Task, app *apps.App) ([
 			Address:           serviceAddress,
 			Tags:              tags,
 			Checks:            checks,
-			EnableTagOverride: true,
+			EnableTagOverride: c.config.EnableTagOverride,
 		})
 	}
 	return registrations, nil

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -70,6 +70,7 @@ func consulClientAtAddress(host string, port int) *Consul {
 		Timeout:             timeutil.Interval{Duration: 10 * time.Second},
 		Port:                fmt.Sprintf("%d", port),
 		ConsulNameSeparator: ".",
+		EnableTagOverride:   true,
 	}
 	consul := New(config)
 	// initialize the agents cache with a single client pointing at provided location

--- a/debian/config.json
+++ b/debian/config.json
@@ -16,7 +16,8 @@
     "Timeout": "3s",
     "AgentFailuresTolerance": 3,
     "RequestRetries": 5,
-    "IgnoredHealthChecks": ""
+    "IgnoredHealthChecks": "",
+    "EnableTagOverride": false
   },
   "Web": {
     "Listen": ":4000",


### PR DESCRIPTION
Add config option to configure to disable the anti-entropy feature
for services. See https://www.consul.io/docs/agent/services.html.