### PR TITLE
Remove unnecessary logging.

### DIFF
--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -163,7 +163,6 @@ func (m Marathon) leaderPoll() error {
 func (m Marathon) get(url string) ([]byte, error) {
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Error(err.Error())
 		return nil, err
 	}
 	request.Header.Add("Accept", "application/json")


### PR DESCRIPTION
Error is returned so there is no need to log it. It should be done by caller.