### PR TITLE
Disable Leader detection with a '*'

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ marathon-protocol           | `http`          | Marathon protocol (http or https
 marathon-ssl-verify         | `true`          | Verify certificates when connecting via SSL
 marathon-timeout            | `30s`           | Time limit for requests made by the Marathon HTTP client. A Timeout of zero means no timeout
 marathon-username           |                 | Marathon username for basic auth
-marathon-leader             |                 | Marathon cluster-wide node name (defaults to <hostname>:8080), the some leader specific calls will be made only if the specified node is the current Marathon-leader")
+marathon-leader             |                 | Marathon cluster-wide node name (defaults to <hostname>:8080), the some leader specific calls will be made only if the specified node is the current Marathon-leader. Set to `*` to always act like a Leader.
 metrics-interval            | `30s`           | Metrics reporting interval
 metrics-location            |                 | Graphite URL (used when metrics-target is set to graphite)
 metrics-prefix              | `default`       | Metrics prefix (default is resolved to <hostname>.<app_name>

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ func (config *Config) parseFlags() {
 	flag.StringVar(&config.Marathon.Protocol, "marathon-protocol", "http", "Marathon protocol (http or https)")
 	flag.StringVar(&config.Marathon.Username, "marathon-username", "", "Marathon username for basic auth")
 	flag.StringVar(&config.Marathon.Password, "marathon-password", "", "Marathon password for basic auth")
-	flag.StringVar(&config.Marathon.Leader, "marathon-leader", "", "Marathon cluster-wide node name (defaults to <hostname>:8080), the some leader specific calls will be made only if the specified node is the current Marathon-leader")
+	flag.StringVar(&config.Marathon.Leader, "marathon-leader", "", "Marathon cluster-wide node name (defaults to <hostname>:8080), the some leader specific calls will be made only if the specified node is the current Marathon-leader. Set to `*` to always act like a Leader.")
 	flag.BoolVar(&config.Marathon.VerifySsl, "marathon-ssl-verify", true, "Verify certificates when connecting via SSL")
 	flag.DurationVar(&config.Marathon.Timeout.Duration, "marathon-timeout", 30*time.Second, "Time limit for requests made by the Marathon HTTP client. A Timeout of zero means no timeout")
 

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -245,6 +245,10 @@ func (m Marathon) urlWithQuery(path string, params params) string {
 }
 
 func (m *Marathon) IsLeader() (bool, error) {
+	if m.MyLeader == "*" {
+		log.Debug("Leader detection disable")
+		return true, nil
+	}
 	if m.MyLeader == "" {
 		if err := m.resolveHostname(); err != nil {
 			return false, fmt.Errorf("Could not resolve hostname: %v", err)


### PR DESCRIPTION
This is useful if you always have only 1 instance running (think of `marathon-consul` as a marathon app ;) ) and marathon address is provided by consul DNS.

Do we missed something?