### PR TITLE
Move defer out of function body.

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,13 +43,15 @@ func main() {
 
 	sync.New(config.Sync, remote, consulInstance, consulInstance.AddAgentsFromApps).StartSyncServicesJob()
 
+	//TODO: Use context instead of stop function.
+	var stopSSE sse.Stop
 	go func() {
-		stopSSE, err := sse.NewHandler(config.SSE, config.Web, remote, consulInstance)
+		stopSSE, err = sse.NewHandler(config.SSE, config.Web, remote, consulInstance)
 		if err != nil {
 			log.WithError(err).Fatal("Cannot instantiate SSE handler")
 		}
-		defer stopSSE()
 	}()
+	defer stopSSE()
 
 	http.HandleFunc("/health", web.HealthHandler)
 


### PR DESCRIPTION
After `sse.NewHandler` was moved to fucntion, `defer` was
called everytime handler was created not just before exiting `main`.