### PR TITLE
 support leader discovery logic so can support port other than 8080

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,7 @@ func (config *Config) parseFlags() {
 	flag.BoolVar(&config.Sync.Enabled, "sync-enabled", true, "Enable Marathon-consul scheduled sync")
 	flag.DurationVar(&config.Sync.Interval.Duration, "sync-interval", 15*time.Minute, "Marathon-consul sync interval")
 	flag.BoolVar(&config.Sync.Force, "sync-force", false, "Force leadership-independent Marathon-consul sync (run always)")
+	flag.IntVar(&config.Sync.Port, "sync-port", 8080, "Marathon port (defaults to 8080)")
 
 	// Marathon
 	flag.StringVar(&config.Marathon.Location, "marathon-location", "localhost:8080", "Marathon URL")

--- a/marathon/marathon.go
+++ b/marathon/marathon.go
@@ -243,13 +243,13 @@ func (m Marathon) urlWithQuery(path string, params params) string {
 	return marathon.String()
 }
 
-func (m *Marathon) IsLeader() (bool, error) {
+func (m *Marathon) IsLeader(port uint32) (bool, error) {
 	if m.MyLeader == "*" {
 		log.Debug("Leader detection disable")
 		return true, nil
 	}
 	if m.MyLeader == "" {
-		if err := m.resolveHostname(); err != nil {
+		if err := m.resolveHostname(port); err != nil {
 			return false, fmt.Errorf("Could not resolve hostname: %v", err)
 		}
 	}
@@ -257,12 +257,12 @@ func (m *Marathon) IsLeader() (bool, error) {
 	return m.MyLeader == leader, err
 }
 
-func (m *Marathon) resolveHostname() error {
+func (m *Marathon) resolveHostname(port uint32) error {
 	hostname, err := hostname()
 	if err != nil {
 		return err
 	}
-	m.MyLeader = fmt.Sprintf("%s:8080", hostname)
+	m.MyLeader = fmt.Sprintf("%s:%s", hostname, port)
 	log.WithField("Leader", m.MyLeader).Info("Marathon Leader mode set to resolved hostname")
 	return nil
 }

--- a/sync/config.go
+++ b/sync/config.go
@@ -6,5 +6,6 @@ type Config struct {
 	Enabled  bool
 	Force    bool
 	Interval time.Interval
+        Port     uint32
 	Leader   string
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -92,7 +92,7 @@ func (s *Sync) shouldPerformSync() (bool, error) {
 		log.Debug("Forcing sync")
 		return true, nil
 	}
-	leading, err := s.marathon.IsLeader()
+	leading, err := s.marathon.IsLeader(s.config.Port)
 	if err != nil {
 		return false, fmt.Errorf("Could not get Marathon leader: %v", err)
 	}


### PR DESCRIPTION
I have no go experience but I thought I would give this a shot. Basically we run Marathon in port 8800 and can not use the marathon-consul feature of having it sync only on the master because marathon-consul can only support finding masters if they run on port 8080 due to the hardcoding of that in the resolveHostname function. This may not be the exact code that you would use but I hope at least I have come close. Thanks!