### PR TITLE
Disable maligned linter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ check-deps: deps
         (go get github.com/alecthomas/gometalinter && gometalinter --install)
 
 check: check-deps $(SOURCES) test
-	gometalinter ./... --deadline  720s --vendor -D dupl -D gotype -D errcheck -D gas -D golint -D aligncheck -D vetshadow -E gofmt
+	gometalinter ./... --deadline  720s --vendor -D dupl -D gotype -D errcheck -D gas -D golint -D aligncheck -D vetshadow -D maligned -E gofmt
 
 format:
 	goimports -w -l $(APP_SOURCES)

--- a/apps/task_test.go
+++ b/apps/task_test.go
@@ -106,17 +106,17 @@ func TestIsHealthy(t *testing.T) {
 	// then
 	assert.True(t, task.IsHealthy())
 
-        // when
-        task.State = "TASK_KILLING"
+	// when
+	task.State = "TASK_KILLING"
 
-        // then
-        assert.False(t, task.IsHealthy())
+	// then
+	assert.False(t, task.IsHealthy())
 
-        // when
-        task.State = "TASK_RUNNING"
+	// when
+	task.State = "TASK_RUNNING"
 
-        // then
-        assert.True(t, task.IsHealthy())
+	// then
+	assert.True(t, task.IsHealthy())
 }
 
 func TestId_String(t *testing.T) {


### PR DESCRIPTION
Disable check due to: 

    consul/config.go:5:13:warning: struct of size 200 could be 192 (maligned)