### PR TITLE
Local Agent used for service list reads (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ consul-auth-password        |                 | The basic authentication passwor
 consul-auth-username        |                 | The basic authentication username
 consul-enable-tag-override  | `false`         | Disable the anti-entropy feature for all services
 consul-ignored-healthchecks |                 | A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp
-consul-local-agent-host     |                 | Consul Agent hostname or IP that should be used for startup sync
+consul-local-agent-host     |                 | Consul Agent hostname or IP that should be used for startup sync and service listing operations
 consul-name-separator       | `.`             | Separator used to create default service name for Consul
 consul-get-services-retry   | `3`             | Number of retries on failure when performing requests to Consul. Each retry uses different cached agent
 consul-max-agent-failures   | `3`             | Max number of consecutive request failures for agent before removal from cache

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -77,7 +77,15 @@ func getPorts(number int) ([]int, error) {
 }
 
 func ClientAtServer(server *testutil.TestServer) *Consul {
-	return consulClientAtAddress(server.Config.Bind, server.Config.Ports.HTTP)
+	return clientAtServer(server, true)
+}
+
+func ClientAtRemoteServer(server *testutil.TestServer) *Consul {
+	return clientAtServer(server, false)
+}
+
+func clientAtServer(server *testutil.TestServer, local bool) *Consul {
+	return consulClientAtAddress(server.Config.Bind, server.Config.Ports.HTTP, local)
 }
 
 func SecuredClientAtServer(server *testutil.TestServer) *Consul {
@@ -97,13 +105,17 @@ func FailingClient() *Consul {
 	return consul
 }
 
-func consulClientAtAddress(host string, port int) *Consul {
+func consulClientAtAddress(host string, port int, local bool) *Consul {
+	localAgent := ""
+	if (local) {
+		localAgent = host
+	}
 	config := Config{
 		Timeout:             timeutil.Interval{Duration: 10 * time.Second},
 		Port:                fmt.Sprintf("%d", port),
 		ConsulNameSeparator: ".",
 		EnableTagOverride:   true,
-		LocalAgentHost:      host,
+		LocalAgentHost:      localAgent,
 	}
 	consul := New(config)
 	// initialize the agents cache with a single client pointing at provided location


### PR DESCRIPTION
If defined, the local consul agent is used to read list of services.
Otherwise, a random agent is picked, but only from the cache of agents
already syncing registrations.
This change prevents situations, where contacting a random agent in the
cluster fails, because it has no ACL-DC configured.