### PR TITLE
Agents interface unification

### DIFF
--- a/consul/agents_test.go
+++ b/consul/agents_test.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"testing"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +57,7 @@ func TestGetAnyAgent(t *testing.T) {
 
 	// then
 	assert.NoError(t, err)
-	assert.Contains(t, []*consulapi.Client{agent1, agent2, agent3}, anyAgent.Client)
+	assert.Contains(t, []*Agent{agent1, agent2, agent3}, anyAgent)
 }
 
 func TestGetAgent_ShouldResolveAddressToIP(t *testing.T) {
@@ -124,7 +123,7 @@ func TestRemoveAgent(t *testing.T) {
 	// then
 	for i := 0; i < 10; i++ {
 		agent, err := agents.GetAnyAgent()
-		assert.Equal(t, agent.Client, agent2)
+		assert.Equal(t, agent, agent2)
 		assert.Equal(t, "127.0.0.2", agent.IP)
 		assert.NoError(t, err)
 	}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -181,6 +181,9 @@ func (c *Consul) register(service *consulapi.AgentServiceRegistration) error {
 	if err != nil {
 		return err
 	}
+
+	client := agent.Client
+
 	fields := log.Fields{
 		"Name":              service.Name,
 		"Id":                service.ID,
@@ -191,7 +194,7 @@ func (c *Consul) register(service *consulapi.AgentServiceRegistration) error {
 	}
 	log.WithFields(fields).Info("Registering")
 
-	err = agent.Agent().ServiceRegister(service)
+	err = client.Agent().ServiceRegister(service)
 	if err != nil {
 		log.WithError(err).WithFields(fields).Error("Unable to register")
 	}
@@ -266,9 +269,11 @@ func (c *Consul) deregister(toDeregister *service.Service) error {
 		return err
 	}
 
+	client := agent.Client
+
 	log.WithField("Id", toDeregister.ID).WithField("Address", toDeregister.RegisteringAgentAddress).Info("Deregistering")
 
-	err = agent.Agent().ServiceDeregister(toDeregister.ID.String())
+	err = client.Agent().ServiceDeregister(toDeregister.ID.String())
 	if err != nil {
 		log.WithError(err).WithField("Id", toDeregister.ID).WithField("Address", toDeregister.RegisteringAgentAddress).Error("Unable to deregister")
 	}


### PR DESCRIPTION
Change `GetAnyAgent` to return `Agent` instead of `Client` to make API consistent.