### PR TITLE
Support Marathon 1.5 Network API

### DIFF
--- a/apps/app.go
+++ b/apps/app.go
@@ -28,6 +28,10 @@ type PortDefinition struct {
 	Labels map[string]string `json:"labels"`
 }
 
+type Container struct {
+	PortMappings []PortDefinition `json:"portMappings"`
+}
+
 type appWrapper struct {
 	App App `json:"app"`
 }
@@ -37,6 +41,7 @@ type Apps struct {
 }
 
 type App struct {
+	Container       Container         `json:"container"`
 	Labels          map[string]string `json:"labels"`
 	HealthChecks    []HealthCheck     `json:"healthChecks"`
 	ID              AppID             `json:"id"`
@@ -162,8 +167,15 @@ type indexedPortDefinition struct {
 }
 
 func (app App) findConsulPortDefinitions() []indexedPortDefinition {
+	var appPortDefinitions []PortDefinition
+	if len(app.Container.PortMappings) > 0 {
+		appPortDefinitions = app.Container.PortMappings
+	} else {
+		appPortDefinitions = app.PortDefinitions
+	}
+	
 	var definitions []indexedPortDefinition
-	for i, d := range app.PortDefinitions {
+	for i, d := range appPortDefinitions {
 		if _, ok := d.Labels[MarathonConsulLabel]; ok {
 			definitions = append(definitions, indexedPortDefinition{
 				Index:  i,
@@ -171,5 +183,6 @@ func (app App) findConsulPortDefinitions() []indexedPortDefinition {
 			})
 		}
 	}
+
 	return definitions
 }

--- a/apps/app.go
+++ b/apps/app.go
@@ -167,15 +167,8 @@ type indexedPortDefinition struct {
 }
 
 func (app App) findConsulPortDefinitions() []indexedPortDefinition {
-	var appPortDefinitions []PortDefinition
-	if len(app.Container.PortMappings) > 0 {
-		appPortDefinitions = app.Container.PortMappings
-	} else {
-		appPortDefinitions = app.PortDefinitions
-	}
-	
 	var definitions []indexedPortDefinition
-	for i, d := range appPortDefinitions {
+	for i, d := range extractPortDefinitions(app) {
 		if _, ok := d.Labels[MarathonConsulLabel]; ok {
 			definitions = append(definitions, indexedPortDefinition{
 				Index:  i,
@@ -185,4 +178,18 @@ func (app App) findConsulPortDefinitions() []indexedPortDefinition {
 	}
 
 	return definitions
+}
+
+// Deprecated: Allows for backward compatibility with Marathons' network API
+// PortDefinitions are deprecated in favor of Marathons' new PortMappings
+// see https://github.com/mesosphere/marathon/pull/5391
+func extractPortDefinitions(app *App) []PortDefinition {
+	var appPortDefinitions []PortDefinition
+	if len(app.Container.PortMappings) > 0 {
+		appPortDefinitions = app.Container.PortMappings
+	} else {
+		appPortDefinitions = app.PortDefinitions
+	}
+	
+	return appPortDefinitions
 }

--- a/apps/app.go
+++ b/apps/app.go
@@ -168,7 +168,7 @@ type indexedPortDefinition struct {
 
 func (app App) findConsulPortDefinitions() []indexedPortDefinition {
 	var definitions []indexedPortDefinition
-	for i, d := range extractPortDefinitions(&app) {
+	for i, d := range app.extractPortDefinitions() {
 		if _, ok := d.Labels[MarathonConsulLabel]; ok {
 			definitions = append(definitions, indexedPortDefinition{
 				Index:  i,
@@ -183,7 +183,7 @@ func (app App) findConsulPortDefinitions() []indexedPortDefinition {
 // Deprecated: Allows for backward compatibility with Marathons' network API
 // PortDefinitions are deprecated in favor of Marathons' new PortMappings
 // see https://github.com/mesosphere/marathon/pull/5391
-func extractPortDefinitions(app *App) []PortDefinition {
+func (app App) extractPortDefinitions() []PortDefinition {
 	var appPortDefinitions []PortDefinition
 	if len(app.Container.PortMappings) > 0 {
 		appPortDefinitions = app.Container.PortMappings

--- a/apps/app.go
+++ b/apps/app.go
@@ -168,7 +168,7 @@ type indexedPortDefinition struct {
 
 func (app App) findConsulPortDefinitions() []indexedPortDefinition {
 	var definitions []indexedPortDefinition
-	for i, d := range extractPortDefinitions(app) {
+	for i, d := range extractPortDefinitions(&app) {
 		if _, ok := d.Labels[MarathonConsulLabel]; ok {
 			definitions = append(definitions, indexedPortDefinition{
 				Index:  i,

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -21,11 +21,11 @@ func TestExtractPortDefintions(t *testing.T) {
 	}
 
 	ports := extractPortDefinitions(&app)
-	assert.Equal(t, app.Container.PortMappings[0].Labels['other'], ports[0].Labels['other'])
+	assert.Equal(t, app.Container.PortMappings[0].Labels["other"], ports[0].Labels["other"])
 
 	app = App{PortDefinitions: definitions}
 	ports := extractPortDefinitions(&app)
-	assert.Equal(t, app.PortDefinitions[0].Labels['other'], ports[0].Labels['other'])
+	assert.Equal(t, app.PortDefinitions[0].Labels["other"], ports[0].Labels["other"])
 }
 
 func TestParseApps(t *testing.T) {

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -24,7 +24,7 @@ func TestExtractPortDefintions(t *testing.T) {
 	assert.Equal(t, app.Container.PortMappings[0].Labels["other"], ports[0].Labels["other"])
 
 	app = App{PortDefinitions: definitions}
-	ports := extractPortDefinitions(&app)
+	ports = extractPortDefinitions(&app)
 	assert.Equal(t, app.PortDefinitions[0].Labels["other"], ports[0].Labels["other"])
 }
 

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -7,6 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestExtractPortDefintions(t *testing.T) {
+	definitions := []PortDefinition{
+		{
+			Labels: map[string]string{"other": "tag"},
+		},
+		{},
+	}
+	app := App{
+		Container: Container{
+			PortMappings: definitions,
+		},
+	}
+
+	ports := extractPortDefinitions(&app)
+	assert.Equal(t, app.Container.PortMappings[0].Labels['other'], ports[0].Labels['other'])
+
+	app = App{PortDefinitions: definitions}
+	ports := extractPortDefinitions(&app)
+	assert.Equal(t, app.PortDefinitions[0].Labels['other'], ports[0].Labels['other'])
+}
+
 func TestParseApps(t *testing.T) {
 	t.Parallel()
 

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -20,11 +20,11 @@ func TestExtractPortDefintions(t *testing.T) {
 		},
 	}
 
-	ports := extractPortDefinitions(&app)
+	ports := app.extractPortDefinitions()
 	assert.Equal(t, app.Container.PortMappings[0].Labels["other"], ports[0].Labels["other"])
 
 	app = App{PortDefinitions: definitions}
-	ports = extractPortDefinitions(&app)
+	ports = app.extractPortDefinitions()
 	assert.Equal(t, app.PortDefinitions[0].Labels["other"], ports[0].Labels["other"])
 }
 


### PR DESCRIPTION
I've manually tested this end-to-end with Marathon, Consul, and this new binary. This patch addresses issue #230 

I'm able to manually compile this code using native `go run`. But I'm not able to run `make build`, etc. So maybe someone (@janisz) can test this? 