### PR TITLE
Release 1.5.1

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -8,7 +8,7 @@
 		"deb-source"
 	],
 	"BuildConstraints": "linux,!arm darwin",
-	"PackageVersion": "1.5.0",
+	"PackageVersion": "1.5.1",
 	"TaskSettings": {
 		"bintray": {
 			"downloadspage": "bintray.md",


### PR DESCRIPTION
Improvements:
* Resolve port placeholders `{port:name}` in Marathon labels (#292)