### PR TITLE
don't search in all DCs if configured

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -8,7 +8,7 @@
 		"deb-source"
 	],
 	"BuildConstraints": "linux,!arm darwin",
-	"PackageVersion": "1.5.1",
+	"PackageVersion": "1.5.2",
 	"TaskSettings": {
 		"bintray": {
 			"downloadspage": "bintray.md",

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ FPM-exists:
 	@fpm -v || \
 	(echo >&2 "FPM must be installed on the system. See https://github.com/jordansissel/fpm"; false)
 
-deb: FPM-exists build
+deb: FPM-exists build-linux
 	mkdir -p dist/$(VERSION)/
 	cd dist/$(VERSION)/ && \
 	fpm -s dir \
@@ -73,6 +73,7 @@ deb: FPM-exists build
         -v $(VERSION) \
         --url="https://github.com/allegro/marathon-consul" \
         --vendor=Allegro \
+        --architecture=amd64 \
         --maintainer="Allegro Group <opensource@allegro.pl>" \
         --description "Marathon-consul service (performs Marathon Tasks registration as Consul Services for service discovery) Marathon-consul takes information provided by the Marathon event bus and forwards it to Consul agents. It also re-syncs all the information from Marathon to Consul on startup and repeats it with given interval." \
         --deb-priority optional \

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ func (config *Config) parseFlags() {
 	flag.StringVar(&config.Consul.IgnoredHealthChecks, "consul-ignored-healthchecks", "", "A comma separated blacklist of Marathon health check types that will not be migrated to Consul, e.g. command,tcp")
 	flag.BoolVar(&config.Consul.EnableTagOverride, "consul-enable-tag-override", false, "Disable the anti-entropy feature for all services")
 	flag.StringVar(&config.Consul.LocalAgentHost, "consul-local-agent-host", "", "Consul Agent hostname or IP that should be used for startup sync")
+	flag.StringVar(&config.Consul.Dc, "consul-dc", "", "Consul DC where to look for services, all if empty")
 
 	// Web
 	flag.StringVar(&config.Web.Listen, "listen", ":4000", "Accept connections at this address")

--- a/consul/config.go
+++ b/consul/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	SslCaCert              string
 	Token                  string
 	Tag                    string
+	Dc                     string
 	Timeout                time.Interval
 	RequestRetries         uint32
 	AgentFailuresTolerance uint32

--- a/consul/consul_test_server.go
+++ b/consul/consul_test_server.go
@@ -23,6 +23,17 @@ func CreateTestServer(t *testing.T) *testutil.TestServer {
 	return server
 }
 
+func CreateTestServerDatacenter(t *testing.T, dc string) *testutil.TestServer {
+	server, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {
+		c.Datacenter = dc
+		c.Ports = testPortConfig(t)
+	})
+
+	assert.NoError(t, err)
+
+	return server
+}
+
 const MasterToken = "masterToken"
 
 func CreateSecuredTestServer(t *testing.T) *testutil.TestServer {


### PR DESCRIPTION
If some datacenter is marked in Consul cluster as "failed" Marathon-Consul still asks for services and fails after getting 500 in response. This PR adds option to configure single datacenter to ask for.